### PR TITLE
Multi-File Ingestion Fix

### DIFF
--- a/operationsgateway_api/src/hdf_handler.py
+++ b/operationsgateway_api/src/hdf_handler.py
@@ -141,10 +141,9 @@ class HDFDataHandler:
                 # Current exception is there as a template only
                 # raise Exception("Duplicate data, will not process")
 
-        # Bug fix where waveform channels are duplicated because the channels are seen
-        # as unique to MongoDB due to the differing waveform IDs each time. This loops
-        # over waveform channels, ignores the waveform IDs and remove ones that have
-        # already been stored
+        # Waveform channels are duplicated because the channels are seen as unique to
+        # MongoDB due to the differing waveform IDs each time. This loops over waveform
+        # channels, ignores the waveform IDs and remove ones that have already been stored
         for stored_channel in stored_data["channels"]:
             if stored_channel["metadata"]["channel_dtype"] == "waveform":
                 for input_channel in input_data["channels"].copy():

--- a/operationsgateway_api/src/routes/ingest_data.py
+++ b/operationsgateway_api/src/routes/ingest_data.py
@@ -63,10 +63,14 @@ async def submit_hdf(file: UploadFile):
         )
         log.debug("Remaining data: %s", remaining_request_data.keys())
         if remaining_request_data:
+            # This update query has been split into two one (which is iterated in a
+            # loop) to add record metadata, and another to add each of the channels.
+            # Based on some quick dev testing while making sure it worked, this doesn't
+            # slow down ingestion times
             for metadata_key, value in remaining_request_data["metadata"].items():
                 await MongoDBInterface.update_one(
                     "records",
-                    {"metadata.shotnum": file_shot_num},
+                    {"_id": remaining_request_data["_id"]},
                     {"$set": {f"metadata.{metadata_key}": value}},
                 )
 


### PR DESCRIPTION
A small PR that fixes a bug regarding multi-file ingestion. Changing the MongoDB queries do most of the work here (`$addToSet` is able to detect where data is identical and therefore won't store it in MongoDB) but a specific piece of code was required to prevent waveform channels from being duplicated:
- I have separated the MongoDB update query into two when a shot already exists - one (which is iterated in a loop) to add record metadata, and another to add each of the channels. Based on some quick dev testing while making sure it worked, this doesn't slow down ingestion times
- Upon separating the MongoDB query, I noticed that waveforms would be duplicated when ingested again. This is because the waveform IDs are generated on the API side, so MongoDB believes the channel is unique. I've fixed this bug in `search_existing_data()` by removing waveform IDs then checking for uniqueness which fixed the issue. You can mindlessly ingest the same file time and time again without adding duplicate record data!
- Also added a TODO towards the start of `search_existing_data()`

I've used the label name for the associated in Jira, mainly as a bit of a test. It seems to show the commit I linked so that's good!