### PR TITLE
DSEGOG-42 Make thumbnails configurable

### DIFF
--- a/operationsgateway_api/config.yml.example
+++ b/operationsgateway_api/config.yml.example
@@ -3,6 +3,8 @@ app:
   port: 8000
   # API will auto-reload when changes on code files are detected
   reload: true
+  image_thumbnail_size: [50, 50]
+  waveform_thumbnail_size: [100, 100]
 logging:
   log_level: DEBUG
   log_location: /var/log/operationsgateway-api.log

--- a/operationsgateway_api/src/config.py
+++ b/operationsgateway_api/src/config.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 import sys
-from typing import Optional
+from typing import Optional, Tuple
 
 from pydantic import (
     BaseModel,
@@ -20,6 +20,10 @@ class App(BaseModel):
     host: Optional[StrictStr]
     port: Optional[StrictInt]
     reload: Optional[StrictBool]
+    # The dimensions will be stored as a list in the YAML file, but are cast to tuple
+    # using `typing.Tuple` because this is the type used by Pillow
+    image_thumbnail_size: Tuple[int, int]
+    waveform_thumbnail_size: Tuple[int, int]
 
 
 class Logging(BaseModel):

--- a/operationsgateway_api/src/helpers.py
+++ b/operationsgateway_api/src/helpers.py
@@ -8,6 +8,7 @@ from bson import ObjectId
 import matplotlib.pyplot as plt
 from PIL import Image
 import pymongo
+from operationsgateway_api.src.config import Config
 
 from operationsgateway_api.src.data_encoding import DataEncoding
 from operationsgateway_api.src.mongo.interface import MongoDBInterface
@@ -80,7 +81,7 @@ def create_image_thumbnails(image_paths):
 
     for path in image_paths:
         image = Image.open(path)
-        create_thumbnail(image, (50, 50))
+        create_thumbnail(image, Config.config.app.image_thumbnail_size)
         thumbnails[path] = convert_image_to_base64(image)
 
     return thumbnails
@@ -126,7 +127,7 @@ def create_waveform_thumbnails(waveforms):
                 plot_buf,
             )
             waveform_image = Image.open(plot_buf)
-            create_thumbnail(waveform_image, (100, 100))
+            create_thumbnail(waveform_image, Config.config.app.waveform_thumbnail_size)
 
             thumbnails[waveform["_id"]] = convert_image_to_base64(waveform_image)
 


### PR DESCRIPTION
This PR makes thumbnail sizes configurable. I've added two new config options, one for image thumbnails and another for waveform thumbnails.

Pydantic will convert the values of these config options from lists to tuples because this is the data type that Pillow expects when it creates a thumbnail. I've added a small comment to explain this.

To test, I dropped the records and waveforms collections in my database, used the script to ingest the 50 shots (in `util/`) to ensure thumbnail creation worked. I pasted some of the base64 strings into an online converter to check they still come back as actual images, and there were no issues.

I've added these new options into the template file in the Ansible repo, as per https://github.com/ral-facilities/operationsgateway-ansible/pull/1