### PR TITLE
DSEGOG-30 Update Postman collection

### DIFF
--- a/util/og_api_postman_collection.json
+++ b/util/og_api_postman_collection.json
@@ -74,9 +74,21 @@
 							"disabled": true
 						},
 						{
+							"key": "conditions",
+							"value": "{\"channels.N_COMP_SPEC_TRACE\": {\"$exists\": true}}",
+							"description": "Return records where N_COMP_SPEC_TRACE channel exists",
+							"disabled": true
+						},
+						{
+							"key": "conditions",
+							"value": "{\"channels.N_LEG1_GREEN_NF_YPOS.data\": {\"$exists\": false}}",
+							"description": "Return records that do not have data for the N_LEG1_GREEN_NF_YPOS channel",
+							"disabled": true
+						},
+						{
 							"key": "projection",
 							"value": "metadata.shotnum",
-							"description": "Return shot numbers only",
+							"description": "Return shot numbers only. Use multiple projection parameters to select multiple fields",
 							"disabled": true
 						},
 						{
@@ -145,6 +157,12 @@
 							"key": "conditions",
 							"value": "{\"$and\": [{\"metadata.timestamp\": {\"$gt\": \"2022-04-07 14:00:00\", \"$lt\": \"2022-04-08 08:00:00\"}}]}",
 							"description": "WHERE timestamp > _ AND < _",
+							"disabled": true
+						},
+						{
+							"key": "conditions",
+							"value": "{\"channels.N_COMP_SPEC_TRACE\": {\"$exists\": true}}",
+							"description": "WHERE the N_COMP_SPEC_TRACE channel exists",
 							"disabled": true
 						}
 					]


### PR DESCRIPTION
This PR updates the Postman collection, with the intention of this being the main way of storing examples of example API usage from now on. 

Each query parameter has a description, and the functionality it demonstrates works on the API:
![image](https://user-images.githubusercontent.com/32678030/180821818-6d9ca29c-ec15-4cbb-b2f1-817ff69ea191.png)

In an ideal world, we should use this as a way to test the API, but I haven't quite figured out how we could leverage this collection in an automated manner.