### PR TITLE
DSEGOG-153 Waveform Thumbnail Design

### DIFF
--- a/operationsgateway_api/src/helpers.py
+++ b/operationsgateway_api/src/helpers.py
@@ -145,9 +145,17 @@ def store_image_thumbnails(record, thumbnails):
 
 
 def create_image_plot(x, y, buf):
-    plt.plot(x, y)
-    plt.savefig(buf, format="PNG")
-    # Flushes figure so axes aren't distorted between figures
+    # Making changes to plot so figure size and line width is correct and axes are
+    # disabled
+    plt.rcParams["figure.figsize"] = [1, 0.75]
+    plt.xticks([])
+    plt.yticks([])
+    plt.plot(x, y, linewidth=0.5)
+    plt.axis("off")
+    plt.box(False)
+
+    plt.savefig(buf, format="PNG", bbox_inches="tight", pad_inches=0, dpi=130)
+    # Flushes the plot to remove data from previously ingested waveforms
     plt.clf()
 
 
@@ -173,8 +181,6 @@ def create_waveform_thumbnails(waveforms):
                 plot_buffer,
             )
             waveform_image = Image.open(plot_buffer)
-            create_thumbnail(waveform_image, Config.config.app.waveform_thumbnail_size)
-
             thumbnails[waveform["_id"]] = convert_image_to_base64(waveform_image)
 
     return thumbnails


### PR DESCRIPTION
This PR improves how waveform thumbnails are created as per feedback from CLF:
- Thumbnail sized images are now created directly from Matplotlib instead of creating a thumbnail from a larger image. This means the image is more sharp instead of being a bit blurry
- Axes (and any associated borders) are removed from the thumbnails to make the data as large as possible
- Line width has been changed to something a bit thicker, a value of 0.5 has been set for the time being

To test, you'll need to ingest some new data containing waveform channels (my script on #22 might be a good source of waveforms) and put the base64 strings into an online converter