### PR TITLE
DSEGOG-168 Fix tests due to new environmental data

### DIFF
--- a/test/endpoints/test_count_records.py
+++ b/test/endpoints/test_count_records.py
@@ -10,7 +10,7 @@ class TestCountRecords:
         [
             pytest.param(
                 {},
-                50,
+                104,
                 id="No conditions",
             ),
             pytest.param(

--- a/test/endpoints/test_get_records.py
+++ b/test/endpoints/test_get_records.py
@@ -12,7 +12,7 @@ class TestGetRecords:
         ", expected_channels_data",
         [
             pytest.param(
-                {},
+                {"metadata.shotnum": {"$exists": True}},
                 0,
                 2,
                 "metadata.shotnum ASC",
@@ -31,10 +31,10 @@ class TestGetRecords:
                 False,
                 [59],
                 [{"N_COMP_FF_XPOS": 323.75}],
-                id="Query with condition",
+                id="Query to retrieve specific shot",
             ),
             pytest.param(
-                {},
+                {"metadata.shotnum": {"$exists": True}},
                 0,
                 2,
                 "metadata.shotnum ASC",


### PR DESCRIPTION
This PR fixes the tests that got broken due to the new environmental data. I have changed the expected count for the count records test failure and added the `{"metadata.shotnum": {"$exists": True}}` condition for `test_get_records.py` to filter out any environmental data