### PR TITLE
Hardcode CI to Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9.7"
+          python-version: "3.8.14"
       - name: Checkout OperationsGateway API
         uses: actions/checkout@v3
 
@@ -141,7 +141,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9.7"
+          python-version: "3.8.14"
       - name: Checkout OperationsGateway API
         uses: actions/checkout@v3
 
@@ -170,7 +170,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9.7"
+          python-version: "3.8.14"
       - name: Checkout OperationsGateway API
         uses: actions/checkout@v3
 


### PR DESCRIPTION
Fix CI as it fails when you setup Python for 3.9.7. GitHub Actions has moved `ubuntu-latest` to 22.04 - we've used 20.04 with no issue (and no reason to move to 22) so I think we should just go back to 20.04.