### PR TITLE
DSEGOG-225 Scalar Data Types

### DIFF
--- a/operationsgateway_api/src/models.py
+++ b/operationsgateway_api/src/models.py
@@ -54,7 +54,10 @@ class ScalarChannelMetadataModel(BaseModel):
 
 class ScalarChannelModel(BaseModel):
     metadata: ScalarChannelMetadataModel
-    data: Union[float, int, str]
+    data: Union[int, float, str]
+
+    class Config:
+        smart_union = True
 
 
 class WaveformChannelMetadataModel(BaseModel):
@@ -142,4 +145,7 @@ class ChannelManifestModel(BaseModel):
 class ChannelSummaryModel(BaseModel):
     first_date: datetime
     most_recent_date: datetime
-    recent_sample: List[Union[float, int, str]]
+    recent_sample: List[Union[int, float, str]]
+
+    class Config:
+        smart_union = True


### PR DESCRIPTION
I noticed a bug where data from scalar channels that should be integers were actually being stored in the database as a float. For example, channels such as `GEM_SHOT_NUM_VALUE` were impacted (e.g. 366271.0 when 366271 should've been stored). 

This bug occurs when data is put into Pydantic models (specifically `ScalarChannelModel`). On the `data` attribute, there are three acceptable types - float, integer and string (which were specified in that order). Because you can cast an integer to a float, that's what Pydantic was doing, instead of moving along to the next type in the `Union` to see if that was a better fit.

I've fixed this bug by using [smart unions](https://docs.pydantic.dev/usage/model_config/#smart-union), a feature in Pydantic. This does exactly what I described at the end of the previous paragraph - it finds the type that best fits the data that you give the model. Hence, channel data such as `GEM_SHOT_NUM_VALUE` is now stored as 366271 (as it should be). Floats are still stored as floats, and strings are unaffected by all this.

Pydantic's documentation warns that smart unions are slower, but I've compared the ingestion script between this branch and main, and there's not a huge difference. I've linked the output of the script from both branches below, but the difference is minimal.

[main_output.txt](https://github.com/ral-facilities/operationsgateway-api/files/10465375/main_output.txt)
[bugfix_output.txt](https://github.com/ral-facilities/operationsgateway-api/files/10465376/bugfix_output.txt)

I believe I introduced this bug during the refactor, which is when I created Pydantic models such as `ScalarChannelModel`. Luckily, this bug hasn't impacted the dev server because we haven't ingested any data since that refactor, so we don't need to re-ingest data on that server.



