### PR TITLE
DSEGOG-230 Add record timestamp to channel sample

### DIFF
--- a/operationsgateway_api/src/models.py
+++ b/operationsgateway_api/src/models.py
@@ -145,7 +145,7 @@ class ChannelManifestModel(BaseModel):
 class ChannelSummaryModel(BaseModel):
     first_date: datetime
     most_recent_date: datetime
-    recent_sample: List[Union[int, float, str]]
+    recent_sample: List[Dict[datetime, Union[int, float, str]]]
 
     class Config:
         smart_union = True

--- a/operationsgateway_api/src/records/record.py
+++ b/operationsgateway_api/src/records/record.py
@@ -211,12 +211,12 @@ class Record:
             channel = record.channels[channel_name]
 
             if channel.metadata.channel_dtype == "scalar":
-                recent_values.append(channel.data)
+                recent_values.append({record.metadata.timestamp: channel.data})
             elif (
                 channel.metadata.channel_dtype == "image"
                 or channel.metadata.channel_dtype == "waveform"
             ):
-                recent_values.append(channel.thumbnail)
+                recent_values.append({record.metadata.timestamp: channel.thumbnail})
 
         return recent_values
 

--- a/test/endpoints/test_channel_summary.py
+++ b/test/endpoints/test_channel_summary.py
@@ -14,7 +14,11 @@ class TestChannelSummary:
                 {
                     "first_date": "2022-04-07T14:16:16",
                     "most_recent_date": "2022-04-08T16:58:57",
-                    "recent_sample": [-8535000.0, -8461000.0, -8582000.0],
+                    "recent_sample": [
+                        {"2022-04-08T16:58:57": -8535000.0},
+                        {"2022-04-08T16:41:36": -8461000.0},
+                        {"2022-04-08T16:29:56": -8582000.0},
+                    ],
                 },
                 id="Scalar channel (number) summary",
             ),
@@ -24,9 +28,9 @@ class TestChannelSummary:
                     "first_date": "2022-04-07T14:16:16",
                     "most_recent_date": "2022-04-08T16:58:57",
                     "recent_sample": [
-                        "FP",
-                        "FP",
-                        "FP",
+                        {"2022-04-08T16:58:57": "FP"},
+                        {"2022-04-08T16:41:36": "FP"},
+                        {"2022-04-08T16:29:56": "FP"},
                     ],
                 },
                 id="Scalar channel (string) summary",
@@ -57,9 +61,9 @@ class TestChannelSummary:
                     "first_date": "2022-04-07T14:16:16",
                     "most_recent_date": "2022-04-08T16:58:57",
                     "recent_sample": [
-                        "10ace7b97cba6d986c5b60250d360988",
-                        "9cf74f5aec5fe857bad5a79c3ed5e0e8",
-                        "bdd30e16457f13cd777209a497e5fb0b",
+                        {"2022-04-08T16:58:57": "10ace7b97cba6d986c5b60250d360988"},
+                        {"2022-04-08T16:41:36": "9cf74f5aec5fe857bad5a79c3ed5e0e8"},
+                        {"2022-04-08T16:29:56": "bdd30e16457f13cd777209a497e5fb0b"},
                     ],
                 },
                 id="Image channel summary",
@@ -70,9 +74,9 @@ class TestChannelSummary:
                     "first_date": "2022-04-07T14:16:16",
                     "most_recent_date": "2022-04-08T16:58:57",
                     "recent_sample": [
-                        "3f542031460398a672779bca52a619a8",
-                        "e30e17ca5249278431cafdb1a250e73c",
-                        "76b91b973c87b877243d237a84c7d40c",
+                        {"2022-04-08T16:58:57": "3f542031460398a672779bca52a619a8"},
+                        {"2022-04-08T16:41:36": "e30e17ca5249278431cafdb1a250e73c"},
+                        {"2022-04-08T16:29:56": "76b91b973c87b877243d237a84c7d40c"},
                     ],
                 },
                 id="Waveform channel summary",
@@ -100,11 +104,12 @@ class TestChannelSummary:
 
         assert test_response.status_code == 200
         json_output = test_response.json()
-        for i in range(len(json_output["recent_sample"])):
-            bytes_thumbnail = base64.b64decode(json_output["recent_sample"][i])
-            json_output["recent_sample"][i] = hashlib.md5(  # noqa: S303
-                bytes_thumbnail,
-            ).hexdigest()
+        for sample in json_output["recent_sample"]:
+            for timestamp, checksum in sample.items():
+                bytes_thumbnail = base64.b64decode(checksum)
+                sample[timestamp] = hashlib.md5(  # noqa: S303
+                    bytes_thumbnail,
+                ).hexdigest()
 
         assert json_output == expected_summary
 


### PR DESCRIPTION
As discussed with the frontend team, this change adds a timestamp (taken from record metadata where the data comes from) to the channel sample on the channel summary endpoint. This changes the samples from a list of values to a list of dictionaries, containing a timestamp and value. Example response:

```json
{
    "first_date": "2022-04-07T14:16:16",
    "most_recent_date": "2022-04-08T16:58:57",
    "recent_sample": [
        {"2022-04-08T14:16:16": -8582000.0},
        {"2022-04-09T14:16:16": -8461000.0},
        {"2022-04-10T14:16:16": -8535000.0}
    ]
}
```