### PR TITLE
DSEGOG-214 Document why `Record.count_records()` couldn't be used

### DIFF
--- a/operationsgateway_api/src/records/image.py
+++ b/operationsgateway_api/src/records/image.py
@@ -109,7 +109,8 @@ class Image:
                 )
                 return false_colour_image
         except (OSError, RuntimeError) as exc:
-            # TODO - change to Record.count_records() and fix the circular import
+            # Record.count_records() could not be used because that would cause a
+            # circular import
             record_count = await MongoDBInterface.count_documents(
                 "records",
                 {


### PR DESCRIPTION
This PR turns a TODO into a comment explaining why `Record.count_records()` hasn't been used. I can't find a clean, easy way to call `Record.count_records()` in the Image class to prevent the circular import. I think it could be done but you'd have to make a few changes across the two classes (put them into a third 'interface' type class) but honestly, I just don't think it's worth it for a single call of that function. Hence I've just explained why it hasn't been done