### PR TITLE
DSEGOG-45 Remove OpenAPI example query parameters

### DIFF
--- a/operationsgateway_api/src/routes/images.py
+++ b/operationsgateway_api/src/routes/images.py
@@ -24,22 +24,10 @@ async def get_full_image(
     record_id: str = Path(  # noqa: B008
         "",
         description="ID of the record (usually timestamp)",
-        examples={
-            "test_data": {
-                "summary": "Example record ID number",
-                "value": "20220408132830",
-            },
-        },
     ),
     channel_name: str = Path(  # noqa: B008
         "",
         description="Channel name containing the image",
-        examples={
-            "test_data": {
-                "summary": "Example image channel name",
-                "value": "N_COMP_FF_IMAGE",
-            },
-        },
     ),
     original_image: Optional[bool] = Query(  # noqa: B008
         False,

--- a/operationsgateway_api/src/routes/records.py
+++ b/operationsgateway_api/src/routes/records.py
@@ -38,21 +38,10 @@ async def get_records(
     order: Optional[List[str]] = Query(  # noqa: B008
         None,
         description="Specify order of results in the format of `field_name ASC`",
-        examples={
-            "asc": {
-                "summary": "Shot number ascending",
-                "value": "metadata.shotnum ASC",
-            },
-            "desc": {"summary": "ID descending", "value": "_id DESC"},
-        },
     ),
     projection: Optional[List[str]] = Query(  # noqa: B008
         None,
         description="Select specific fields in the record e.g. `metadata.shotnum`",
-        examples={
-            "metadata": {"summary": "Shot number", "value": "metadata.shotnum"},
-            "channel_data": {"summary": "Channel data", "value": "channels.data"},
-        },
     ),
     truncate: Optional[bool] = Query(  # noqa: B008
         False,

--- a/operationsgateway_api/src/routes/waveforms.py
+++ b/operationsgateway_api/src/routes/waveforms.py
@@ -22,22 +22,10 @@ async def get_waveform_by_id(
     record_id: str = Path(  # noqa: B008
         "",
         description="ID of the record (usually timestamp)",
-        examples={
-            "test_data": {
-                "summary": "Example record ID number",
-                "value": "20220408140310",
-            },
-        },
     ),
     channel_name: str = Path(  # noqa: B008
         "",
         description="Channel name containing the waveform",
-        examples={
-            "test_data": {
-                "summary": "Example waveform channel name",
-                "value": "N_COMP_SPEC_TRACE",
-            },
-        },
     ),
     access_token: str = Depends(authorise_token),  # noqa: B008
 ):


### PR DESCRIPTION
This JIRA issue is to fix the bugs on the OpenAPI interface caused by some of the conflicting examples. As we use Postman now to document our examples to demonstrate the potential functionality of the API, removing the query parameter examples seems like the best way to resolve the OpenAPI usage issues without spending hours effectively replicating the examples we provide in the Postman collection