### PR TITLE
DSEGOG-219 Remove TODO

### DIFF
--- a/operationsgateway_api/src/models.py
+++ b/operationsgateway_api/src/models.py
@@ -35,7 +35,6 @@ class ImageChannelMetadataModel(BaseModel):
     exposure_time_s: Optional[float]
     gain: Optional[float]
     x_pixel_size: Optional[float]
-    # TODO - UTF8 issue? \u00b5m
     x_pixel_units: Optional[str]
     y_pixel_size: Optional[float]
     y_pixel_units: Optional[str]


### PR DESCRIPTION
A one-liner to remove a TODO. I've spent quite a while trying to recreate a UTF8 error that I came across a few months ago when ingesting some non dev server data but I haven't been able to recreate it. I think it's best to remove the TODO and see if it reappears when the simulated EPAC data is given to us in a few months time