### PR TITLE
DSEGOG-245 Relax codecov checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,11 @@
 github_checks:
     annotations: false
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5
+    patch:
+      default:
+        target: 70


### PR DESCRIPTION
As discussed, a small change to make codecov checks less strict, in the hope that we don't make them fail as often as we sometimes do. 

I've checked the config is valid by following the instructions at https://docs.codecov.com/docs/codecov-yaml#validate-your-repository-yaml