### PR TITLE
Fix colourmap mapping file path

### DIFF
--- a/operationsgateway_api/src/records/colourmap_mapping.py
+++ b/operationsgateway_api/src/records/colourmap_mapping.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from typing import Dict, List
 
 from operationsgateway_api.src.exceptions import ImageError
@@ -21,7 +22,7 @@ class ColourmapMapping:
 
         try:
             with open(
-                "operationsgateway_api/src/records/colourmap_mapping.json",
+                Path(__file__).parent / "colourmap_mapping.json",
             ) as mapping_file:
                 colourmap_mapping = json.load(mapping_file)
         except OSError as exc:


### PR DESCRIPTION
This PR fixes an issue I encountered when deploying the API onto the dev server. This was caused by a hardcoded path string, meaning the file couldn't be opened when the code was installed into a virtualenv (instead of running in a developer's environment). As a result, the API didn't start-up correctly.

I fixed this by using `pathlib` to find the file by using `.parent` (equivalent to `cd ..` but in code), a similar approach to how the config file is found in `config.py`.

This change is currently deployed on the dev server so has effectively been tested.