### PR TITLE
DSEGOG-261 Use ObjectIds in ExperimentModel

### DIFF
--- a/operationsgateway_api/src/experiments/experiment.py
+++ b/operationsgateway_api/src/experiments/experiment.py
@@ -72,15 +72,39 @@ class Experiment:
         that haven't yet been inserted into the database
         """
 
+        inserted_ids = []
         for experiment in self.experiments:
-            await MongoDBInterface.update_one(
-                "experiments",
-                {"_id": experiment.id_},
-                {"$set": experiment.dict(by_alias=True)},
-                upsert=True,
+            experiment_data = experiment.dict(
+                by_alias=True,
+                exclude_unset=True,
+                exclude={"id_"},
             )
 
+            update_result = await MongoDBInterface.update_one(
+                "experiments",
+                experiment_data,
+                {"$set": experiment_data},
+                upsert=True,
+            )
+            # This means the document was updated, not inserted. The _id needs to be
+            # found to be used as a response
+            if update_result.upserted_id is None:
+                updated_experiment = await MongoDBInterface.find_one(
+                    "experiments",
+                    experiment_data,
+                )
+
+                log.debug(
+                    "Experiment was updated, found experiment _id: %s",
+                    str(updated_experiment["_id"]),
+                )
+                inserted_ids.append(f"Updated {str(updated_experiment['_id'])}")
+            else:
+                inserted_ids.append(str(update_result.upserted_id))
+
         await self._update_modification_time()
+
+        return inserted_ids
 
     def _map_experiments_to_part_numbers(
         self,
@@ -157,7 +181,6 @@ class Experiment:
                     ):
                         self.experiments.append(
                             ExperimentModel(
-                                _id=f"{part.referenceNumber}-{part.partNumber}",
                                 experiment_id=int(part.referenceNumber),
                                 part=part.partNumber,
                                 start_date=part.experimentStartDate,

--- a/operationsgateway_api/src/experiments/experiment.py
+++ b/operationsgateway_api/src/experiments/experiment.py
@@ -66,7 +66,7 @@ class Experiment:
         experiments = self.scheduler.get_experiments(ids_for_scheduler_call)
         self._extract_experiment_data(experiments, experiment_parts)
 
-    async def store_experiments(self) -> None:
+    async def store_experiments(self) -> List[str]:
         """
         Store the experiments into MongoDB, using `upsert` to insert any experiments
         that haven't yet been inserted into the database

--- a/operationsgateway_api/src/models.py
+++ b/operationsgateway_api/src/models.py
@@ -8,6 +8,18 @@ from pydantic import BaseModel, Field, root_validator, validator
 from operationsgateway_api.src.exceptions import ChannelManifestError, ModelError
 
 
+class PyObjectId(ObjectId):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        if not isinstance(v, ObjectId):
+            raise TypeError("ObjectId required")
+        return str(v)
+
+
 class ImageModel(BaseModel):
     path: str
     data: np.ndarray
@@ -152,11 +164,14 @@ class ChannelSummaryModel(BaseModel):
 
 
 class ExperimentModel(BaseModel):
-    id_: str = Field(alias="_id")
+    id_: Optional[PyObjectId] = Field(alias="_id")
     experiment_id: str
     part: int
     start_date: datetime
     end_date: datetime
+
+    class Config:
+        arbitrary_types_allowed = True
 
 
 class ShotnumConverterRange(BaseModel):
@@ -185,18 +200,6 @@ class DateConverterRange(BaseModel):
             raise ModelError("to cannot be less than from value")
         else:
             return value
-
-
-class PyObjectId(ObjectId):
-    @classmethod
-    def __get_validators__(cls):
-        yield cls.validate
-
-    @classmethod
-    def validate(cls, v):
-        if not isinstance(v, ObjectId):
-            raise TypeError("ObjectId required")
-        return str(v)
 
 
 class UserSessionModel(BaseModel):

--- a/operationsgateway_api/src/routes/experiments.py
+++ b/operationsgateway_api/src/routes/experiments.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List
 
 from fastapi import APIRouter, Depends
 
@@ -8,6 +9,7 @@ from operationsgateway_api.src.auth.authorisation import (
 )
 from operationsgateway_api.src.error_handling import endpoint_error_handling
 from operationsgateway_api.src.experiments.experiment import Experiment
+from operationsgateway_api.src.models import ExperimentModel
 
 log = logging.getLogger()
 router = APIRouter()
@@ -25,9 +27,8 @@ async def store_experiments_from_scheduler(
 ):
     experiment = Experiment()
     await experiment.get_experiments_from_scheduler()
-    await experiment.store_experiments()
-
-    return [e.id_ for e in experiment.experiments]
+    experiment_ids = await experiment.store_experiments()
+    return experiment_ids
 
 
 @router.get(
@@ -35,6 +36,7 @@ async def store_experiments_from_scheduler(
     summary="Get experiments stored in database",
     response_description="List of experiments",
     tags=["Experiments"],
+    response_model=List[ExperimentModel],
 )
 @endpoint_error_handling
 async def get_experiments(

--- a/test/endpoints/test_get_experiments.py
+++ b/test/endpoints/test_get_experiments.py
@@ -17,21 +17,18 @@ class TestGetExperiments:
         # single experiment
         expected_experiments_snippet = [
             {
-                "_id": "18325019-4",
                 "end_date": "2020-01-06T18:00:00",
                 "experiment_id": "18325019",
                 "part": 4,
                 "start_date": "2020-01-03T10:00:00",
             },
             {
-                "_id": "18325019-5",
                 "end_date": "2019-06-12T17:00:00",
                 "experiment_id": "18325019",
                 "part": 5,
                 "start_date": "2019-06-12T09:00:00",
             },
             {
-                "_id": "20310001-1",
                 "end_date": "2020-02-24T18:00:00",
                 "experiment_id": "20310001",
                 "part": 1,
@@ -50,8 +47,18 @@ class TestGetExperiments:
         for expected_experiment in expected_experiments_snippet:
             experiment_found = False
             for experiment in test_experiments:
-                if experiment["_id"] == expected_experiment["_id"]:
+                if (
+                    experiment["experiment_id"] == expected_experiment["experiment_id"]
+                    and experiment["part"] == expected_experiment["part"]
+                ):
                     experiment_found = True
+
+                    try:
+                        # _id is an object ID so cannot be asserted against
+                        del experiment["_id"]
+                    except KeyError:
+                        pass
+
                     assert experiment == expected_experiment
                     break
 

--- a/test/experiments/scheduler_mocking/experiments_mocks.py
+++ b/test/experiments/scheduler_mocking/experiments_mocks.py
@@ -88,21 +88,21 @@ mock_data = {
         ),
         "expected": [
             ExperimentModel(
-                _id="20310000-1",
+                _id=None,
                 experiment_id=20310000,
                 part=1,
                 start_date=datetime(2020, 2, 25, 10, 0),
                 end_date=datetime(2020, 2, 25, 18, 0),
             ),
             ExperimentModel(
-                _id="20310000-2",
+                _id=None,
                 experiment_id=20310000,
                 part=2,
                 start_date=datetime(2020, 2, 26, 10, 0),
                 end_date=datetime(2020, 2, 26, 18, 0),
             ),
             ExperimentModel(
-                _id="20310000-3",
+                _id=None,
                 experiment_id=20310000,
                 part=3,
                 start_date=datetime(2020, 3, 2, 10, 0),
@@ -138,21 +138,21 @@ mock_data = {
         ),
         "expected": [
             ExperimentModel(
-                _id="20310001-1",
+                _id=None,
                 experiment_id=20310001,
                 part=1,
                 start_date=datetime(2020, 2, 24, 10, 0),
                 end_date=datetime(2020, 2, 24, 18, 0),
             ),
             ExperimentModel(
-                _id="20310001-2",
+                _id=None,
                 experiment_id=20310001,
                 part=2,
                 start_date=datetime(2020, 2, 25, 10, 0),
                 end_date=datetime(2020, 2, 25, 18, 0),
             ),
             ExperimentModel(
-                _id="20310001-3",
+                _id=None,
                 experiment_id=20310001,
                 part=3,
                 start_date=datetime(2020, 2, 26, 10, 0),
@@ -174,7 +174,7 @@ mock_data = {
         ),
         "expected": [
             ExperimentModel(
-                _id="20310002-1",
+                _id=None,
                 experiment_id=20310002,
                 part=1,
                 start_date=datetime(2020, 4, 30, 10, 0),
@@ -231,35 +231,35 @@ mock_data = {
         ),
         "expected": [
             ExperimentModel(
-                _id="18325019-1",
+                _id=None,
                 experiment_id=18325019,
                 part=1,
                 start_date=datetime(2018, 11, 23, 10, 0),
                 end_date=datetime(2018, 11, 23, 18, 0),
             ),
             ExperimentModel(
-                _id="18325019-2",
+                _id=None,
                 experiment_id=18325019,
                 part=2,
                 start_date=datetime(2018, 11, 30, 10, 0),
                 end_date=datetime(2018, 12, 1, 18, 0),
             ),
             ExperimentModel(
-                _id="18325019-3",
+                _id=None,
                 experiment_id=18325019,
                 part=3,
                 start_date=datetime(2018, 11, 29, 10, 0),
                 end_date=datetime(2018, 12, 1, 18, 0),
             ),
             ExperimentModel(
-                _id="18325019-4",
+                _id=None,
                 experiment_id=18325019,
                 part=4,
                 start_date=datetime(2020, 1, 3, 10, 0),
                 end_date=datetime(2020, 1, 6, 18, 0),
             ),
             ExperimentModel(
-                _id="18325019-5",
+                _id=None,
                 experiment_id=18325019,
                 part=5,
                 start_date=datetime(2019, 6, 12, 10, 0),
@@ -366,21 +366,21 @@ mock_data = {
         ),
         "expected": [
             ExperimentModel(
-                _id="12345678-1",
+                _id=None,
                 experiment_id=12345678,
                 part=1,
                 start_date=datetime(2020, 4, 30, 10, 0),
                 end_date=datetime(2020, 4, 30, 18, 0),
             ),
             ExperimentModel(
-                _id="12345678-2",
+                _id=None,
                 experiment_id=12345678,
                 part=2,
                 start_date=datetime(2020, 5, 1, 10, 0),
                 end_date=datetime(2020, 5, 1, 18, 0),
             ),
             ExperimentModel(
-                _id="12345678-4",
+                _id=None,
                 experiment_id=12345678,
                 part=4,
                 start_date=datetime(2020, 5, 3, 10, 0),


### PR DESCRIPTION
This PR changes the `_id` in the `ExperimentModel` to use `ObjectId`s. Previously, this field was filled with a concatenation of the experiment ID and the part number. However, in the simulated EPAC data, experiment IDs for maintenance periods are stored as `maintenance`. In the case of the generated data, they were all experiments with a part number of 1.

Given current discussions regarding parts, it's unclear if this'll be the case in production so I've decided to move to using ObjectIds. We use these in the user session functionality so wasn't too bad to make this change (I was a bit scared of them before). Even the tests didn't require too much work!