### PR TITLE
Improve exception logging when API exception is caught

### DIFF
--- a/operationsgateway_api/src/error_handling.py
+++ b/operationsgateway_api/src/error_handling.py
@@ -21,6 +21,7 @@ def endpoint_error_handling(method):
             return await method(*args, **kwargs)
         except ApiError as exc:
             log.error("Error in endpoint '%s': %s", method.__name__, exc.args[0])
+            log.exception(msg=exc.args)
             raise HTTPException(exc.status_code, exc.args[0]) from exc
         except Exception as exc:
             log.exception(msg=exc.args)


### PR DESCRIPTION
Whilst doing some development the other day, I caused an unintended `AttributeError` in a try/except block where an `ExperimentDetailsError is raised. This is the [try/except block in question](https://github.com/ral-facilities/operationsgateway-api/blob/main/operationsgateway_api/src/experiments/experiment.py#L101). 

When the code executed, I had the following log:
```python
ERROR:   Error in endpoint 'store_experiments_from_scheduler': 'NoneType' object has no attribute 'parts'
```

This wasn't very helpful as I wasn't actually sure where this was coming from, so I spent a little while tracking down where I had gone wrong. This PR should resolve this in the future - any exceptions that are caught by our decorator will now log the traceback. So the same error now logs the following:

```python
ERROR:   ("'NoneType' object has no attribute 'parts'",)
Traceback (most recent call last):
  File "/root/dev/operationsgateway-api/operationsgateway_api/src/experiments/experiment.py", line 209, in _extract_experiment_data
    my_var.parts = "21"
AttributeError: 'NoneType' object has no attribute 'parts'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/root/dev/operationsgateway-api/operationsgateway_api/src/error_handling.py", line 21, in wrapper_error_handling
    return await method(*args, **kwargs)
  File "/root/dev/operationsgateway-api/operationsgateway_api/src/routes/experiments.py", line 27, in store_experiments_from_scheduler
    await experiment.get_experiments_from_scheduler()
  File "/root/dev/operationsgateway-api/operationsgateway_api/src/experiments/experiment.py", line 84, in get_experiments_from_scheduler
    self._extract_experiment_data(experiments, experiment_part_mappings)
  File "/root/dev/operationsgateway-api/operationsgateway_api/src/experiments/experiment.py", line 211, in _extract_experiment_data
    raise ExperimentDetailsError(str(exc)) from exc
operationsgateway_api.src.exceptions.ExperimentDetailsError: 'NoneType' object has no attribute 'parts'
```

So now I have the line number and filename of where the error is caused, plus a traceback to follow.