### PR TITLE
DSEGOG-258 Multiple Instrument Support for Experiments Functionality

### DIFF
--- a/.github/ci_config.yml
+++ b/.github/ci_config.yml
@@ -42,5 +42,6 @@ experiments:
   # Number of minutes to wait before retrying if the background task of getting new
   # experiments from the Scheduler fails
   scheduler_background_retry_mins: 20
-  instrument_name: Gemini
+  instrument_names:
+    - Gemini
   worker_file_path: /dev/shm/og-experiment-background

--- a/operationsgateway_api/config.yml.example
+++ b/operationsgateway_api/config.yml.example
@@ -48,5 +48,6 @@ experiments:
   # Number of minutes to wait before retrying if the background task of getting new
   # experiments from the Scheduler fails
   scheduler_background_retry_mins: 20
-  instrument_name: Gemini
+  instrument_names:
+    - Gemini
   worker_file_path: /dev/shm/og-experiment-background

--- a/operationsgateway_api/src/config.py
+++ b/operationsgateway_api/src/config.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from pathlib import Path
 import sys
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 from dateutil import tz
 from pydantic import (
@@ -67,7 +67,7 @@ class ExperimentsConfig(BaseModel):
     username: StrictStr
     password: StrictStr
     scheduler_wsdl_url: StrictStr
-    instrument_name: StrictStr
+    instrument_names: List[StrictStr]
     worker_file_path: StrictStr
 
     @validator("scheduler_background_timezone")

--- a/operationsgateway_api/src/experiments/experiment.py
+++ b/operationsgateway_api/src/experiments/experiment.py
@@ -90,7 +90,7 @@ class Experiment:
         self,
         # List of zeep experimentDateDTO's
         experiments: List[Any],
-        instrument_name: str
+        instrument_name: str,
     ) -> List[ExperimentPartMappingModel]:
         """
         Given a list of experiments retrieved from the Scheduler, extract RB numbers

--- a/operationsgateway_api/src/experiments/experiment.py
+++ b/operationsgateway_api/src/experiments/experiment.py
@@ -230,20 +230,16 @@ class Experiment:
         a matching experiment ID
         """
 
-        part_mapping = None
         for mapping in mapping_models:
             if mapping.experiment_id == experiment_id:
                 return mapping
 
-        if not part_mapping:
-            log.error(
-                "Part mapping for %s failed. Mapping to search through: %s",
-                experiment_id,
-                mapping_models,
-            )
-            raise ExperimentDetailsError(
-                f"Lookup of part mapping {experiment_id} failed",
-            )
+        log.error(
+            "Part mapping for %s failed. Mapping to search through: %s",
+            experiment_id,
+            mapping_models,
+        )
+        raise ExperimentDetailsError(f"Lookup of part mapping {experiment_id} failed")
 
     def _detect_duplicate_parts(
         self,

--- a/operationsgateway_api/src/experiments/experiment.py
+++ b/operationsgateway_api/src/experiments/experiment.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 import logging
-from typing import Dict, List, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 from pydantic import ValidationError
 
@@ -11,7 +11,7 @@ from operationsgateway_api.src.experiments.duplicate_part_selector import (
 )
 import operationsgateway_api.src.experiments.runners as runners
 from operationsgateway_api.src.experiments.scheduler_interface import SchedulerInterface
-from operationsgateway_api.src.models import ExperimentModel
+from operationsgateway_api.src.models import ExperimentModel, ExperimentPartMappingModel
 from operationsgateway_api.src.mongo.interface import MongoDBInterface
 from operationsgateway_api.src.routes.common_parameters import ParameterHandler
 
@@ -53,18 +53,22 @@ class Experiment:
             experiment_search_end_date,
         )
 
-        exp_data = self.scheduler.get_experiment_dates_for_instrument(
-            experiment_search_start_date,
-            experiment_search_end_date,
-        )
+        experiment_part_mappings = []
+        for instrument_name in Config.config.experiments.instrument_names:
+            exp_data = self.scheduler.get_experiment_dates_for_instrument(
+                instrument_name,
+                experiment_search_start_date,
+                experiment_search_end_date,
+            )
+            experiment_part_mappings.extend(
+                self._map_experiments_to_part_numbers(exp_data, instrument_name),
+            )
 
-        experiment_parts = self._map_experiments_to_part_numbers(exp_data)
         ids_for_scheduler_call = self._generate_id_instrument_name_pairs(
-            experiment_parts,
+            experiment_part_mappings,
         )
-
         experiments = self.scheduler.get_experiments(ids_for_scheduler_call)
-        self._extract_experiment_data(experiments, experiment_parts)
+        self._extract_experiment_data(experiments, experiment_part_mappings)
 
     async def store_experiments(self) -> None:
         """
@@ -84,13 +88,15 @@ class Experiment:
 
     def _map_experiments_to_part_numbers(
         self,
-        experiments: list,
-    ) -> Dict[int, List[int]]:
+        # List of zeep experimentDateDTO's
+        experiments: List[Any],
+        instrument_name: str
+    ) -> List[ExperimentPartMappingModel]:
         """
-        Extracts the rb number (experiment ID) and the experiment's part and puts them
-        into a dictionary to get start and end dates for each one.
-
-        Example output: {19510004: [1], 20310000: [1, 2, 3]}
+        Given a list of experiments retrieved from the Scheduler, extract RB numbers
+        (experiment IDs) and the experiment's parts and return a list of experiment part
+        mappings that contain this data and which instrument the experiment/its parts
+        belong to
         """
 
         exp_parts = {}
@@ -102,29 +108,50 @@ class Experiment:
                 raise ExperimentDetailsError(str(exc)) from exc
 
         log.debug("Experiment parts: %s", exp_parts)
-        return exp_parts
+
+        part_mappings = [
+            ExperimentPartMappingModel(
+                experiment_id=exp_id,
+                parts=parts,
+                instrument_name=instrument_name,
+            )
+            for exp_id, parts in exp_parts.items()
+        ]
+
+        return part_mappings
 
     def _generate_id_instrument_name_pairs(
         self,
-        experiment_parts: Dict[int, List[int]],
+        experiment_part_mappings: List[ExperimentPartMappingModel],
     ) -> List[Dict[str, Union[str, int]]]:
         """
         Generate a list of dictionaries in the format accepted by the Scheduler to get
-        details of multiple experiments
+        details of multiple experiments. If duplicate part mappings are passed, only one
+        pair should be returned.
         """
 
         id_name_pairs = [
-            {"key": experiment_id, "value": Config.config.experiments.instrument_name}
-            for experiment_id in experiment_parts.keys()
+            {"key": mapping.experiment_id, "value": mapping.instrument_name}
+            for mapping in experiment_part_mappings
         ]
-        log.debug("Experiments to query for: %s", id_name_pairs)
 
-        return id_name_pairs
+        # Create a list of tuples (which are hashable) containing dictionary items,
+        # store them in a set to remove duplicates and convert the remaining tuples back
+        # into dictionaries, stored in a list
+        duplicates_removed = [
+            dict(t) for t in {tuple(d.items()) for d in id_name_pairs}
+        ]
+        # Testing revealed the above list comprehension doesn't guarantee the order of
+        # the dictionaries so explict sorting is needed
+        ordered_list = sorted(duplicates_removed, key=lambda d: d["key"])
+        log.debug("Experiments to query for: %s", ordered_list)
+
+        return ordered_list
 
     def _extract_experiment_data(
         self,
         experiments: list,
-        experiment_part_mapping: Dict[int, List[int]],
+        experiment_part_mappings: List[ExperimentPartMappingModel],
     ) -> None:
         """
         Extract relevant attributes from experiment data that the Scheduler responded
@@ -145,16 +172,17 @@ class Experiment:
                 # Combine selected duplicate parts with non duplicates and sort based on
                 # experiment ID and part number
                 experiment_parts = selected_parts + non_duplicate_parts
-                list.sort(
-                    experiment_parts,
+                experiment_parts.sort(
                     key=lambda part: (part.referenceNumber, part.partNumber),
                 )
 
                 for part in experiment_parts:
-                    if (
-                        part.partNumber
-                        in experiment_part_mapping[int(part.referenceNumber)]
-                    ):
+                    part_mapping = self._get_mapping_model_by_experiment_id(
+                        int(part.referenceNumber),
+                        experiment_part_mappings,
+                    )
+
+                    if part.partNumber in part_mapping.parts:
                         self.experiments.append(
                             ExperimentModel(
                                 _id=f"{part.referenceNumber}-{part.partNumber}",

--- a/operationsgateway_api/src/experiments/experiment.py
+++ b/operationsgateway_api/src/experiments/experiment.py
@@ -169,6 +169,31 @@ class Experiment:
             except ValidationError as exc:
                 raise ModelError(str(exc)) from exc
 
+    def _get_mapping_model_by_experiment_id(
+        self,
+        experiment_id: int,
+        mapping_models: List[ExperimentPartMappingModel],
+    ):
+        """
+        Search through a list of experiment part mapping models and return the one with
+        a matching experiment ID
+        """
+
+        part_mapping = None
+        for mapping in mapping_models:
+            if mapping.experiment_id == experiment_id:
+                return mapping
+
+        if not part_mapping:
+            log.error(
+                "Part mapping for %s failed. Mapping to search through: %s",
+                experiment_id,
+                mapping_models,
+            )
+            raise ExperimentDetailsError(
+                f"Lookup of part mapping {experiment_id} failed",
+            )
+
     def _detect_duplicate_parts(
         self,
         experiment,

--- a/operationsgateway_api/src/experiments/scheduler_interface.py
+++ b/operationsgateway_api/src/experiments/scheduler_interface.py
@@ -45,6 +45,7 @@ class SchedulerInterface:
     @soap_error_handling("getExperimentDatesForInstrument")
     def get_experiment_dates_for_instrument(
         self,
+        instrument_name: str,
         start_date: datetime,
         end_date: datetime,
     ) -> list:
@@ -54,7 +55,7 @@ class SchedulerInterface:
         log.info("Calling Scheduler getExperimentDatesForInstrument()")
         return self.scheduler_client.service.getExperimentDatesForInstrument(
             self.session_id,
-            Config.config.experiments.instrument_name,
+            instrument_name,
             {
                 "startDate": start_date,
                 "endDate": end_date,

--- a/operationsgateway_api/src/models.py
+++ b/operationsgateway_api/src/models.py
@@ -164,6 +164,7 @@ class ExperimentPartMappingModel(BaseModel):
     parts: List[int]
     instrument_name: str
 
+
 class ShotnumConverterRange(BaseModel):
     opposite_range_fields: ClassVar[Dict[str, str]] = {"from": "min_", "to": "max_"}
 

--- a/operationsgateway_api/src/models.py
+++ b/operationsgateway_api/src/models.py
@@ -159,6 +159,11 @@ class ExperimentModel(BaseModel):
     end_date: datetime
 
 
+class ExperimentPartMappingModel(BaseModel):
+    experiment_id: int
+    parts: List[int]
+    instrument_name: str
+
 class ShotnumConverterRange(BaseModel):
     opposite_range_fields: ClassVar[Dict[str, str]] = {"from": "min_", "to": "max_"}
 

--- a/test/experiments/test_experiment.py
+++ b/test/experiments/test_experiment.py
@@ -21,7 +21,7 @@ from test.experiments.scheduler_mocking.get_exp_dates_mocks import (
 
 class TestExperiment:
     # Variables that are used for mocking
-    config_instrument_names = ["Test Instrument"]
+    config_instrument_names = ["Test Instrument", "Test Instrument #2"]
     config_scheduler_contact_date = datetime(2023, 3, 2, 10, 0)
     experiment_search_start_date = "2020-01-01T00:00:00Z"
     experiment_search_end_date = "2020-05-01T00:00:00Z"
@@ -200,20 +200,20 @@ class TestExperiment:
                     ExperimentPartMappingModel(
                         experiment_id=20310002,
                         parts=[2, 3, 4, 5, 6],
-                        instrument_name=config_instrument_names[0],
+                        instrument_name=config_instrument_names[1],
                     ),
                     ExperimentPartMappingModel(
                         experiment_id=20310003,
                         parts=[1, 2],
-                        instrument_name=config_instrument_names[0],
+                        instrument_name=config_instrument_names[1],
                     ),
                 ],
                 [
                     {"key": 19510004, "value": config_instrument_names[0]},
                     {"key": 20310000, "value": config_instrument_names[0]},
                     {"key": 20310001, "value": config_instrument_names[0]},
-                    {"key": 20310002, "value": config_instrument_names[0]},
-                    {"key": 20310003, "value": config_instrument_names[0]},
+                    {"key": 20310002, "value": config_instrument_names[1]},
+                    {"key": 20310003, "value": config_instrument_names[1]},
                 ],
                 id="Multiple experiments",
             ),
@@ -254,8 +254,8 @@ class TestExperiment:
         return_value=[
             {"key": 20310000, "value": config_instrument_names[0]},
             {"key": 20310001, "value": config_instrument_names[0]},
-            {"key": 18325019, "value": config_instrument_names[0]},
-            {"key": 20310002, "value": config_instrument_names[0]},
+            {"key": 18325019, "value": config_instrument_names[1]},
+            {"key": 20310002, "value": config_instrument_names[1]},
         ],
     )
     @patch(
@@ -281,12 +281,12 @@ class TestExperiment:
                     ExperimentPartMappingModel(
                         experiment_id=18325019,
                         parts=[4],
-                        instrument_name=config_instrument_names[0],
+                        instrument_name=config_instrument_names[1],
                     ),
                     ExperimentPartMappingModel(
                         experiment_id=20310002,
                         parts=[1],
-                        instrument_name=config_instrument_names[0],
+                        instrument_name=config_instrument_names[1],
                     ),
                 ],
                 {
@@ -308,7 +308,7 @@ class TestExperiment:
                     ExperimentPartMappingModel(
                         experiment_id=18325019,
                         parts=[3, 4, 5],
-                        instrument_name=config_instrument_names[0],
+                        instrument_name=config_instrument_names[1],
                     ),
                 ],
                 {20310000: [1, 2], 18325019: [3, 4, 5]},
@@ -468,7 +468,7 @@ class TestExperiment:
                     ExperimentPartMappingModel(
                         experiment_id=20310000,
                         parts=[3, 2, 1],
-                        instrument_name=config_instrument_names[0],
+                        instrument_name=config_instrument_names[1],
                     ),
                     ExperimentPartMappingModel(
                         experiment_id=20310001,
@@ -484,7 +484,7 @@ class TestExperiment:
                 ExperimentPartMappingModel(
                     experiment_id=20310000,
                     parts=[3, 2, 1],
-                    instrument_name=config_instrument_names[0],
+                    instrument_name=config_instrument_names[1],
                 ),
                 id="Multi-part list",
             ),

--- a/test/experiments/test_experiment.py
+++ b/test/experiments/test_experiment.py
@@ -27,11 +27,13 @@ class TestExperiment:
     experiment_search_end_date = "2020-05-01T00:00:00Z"
 
     @patch(
-        "operationsgateway_api.src.experiments.scheduler_interface.SchedulerInterface.__init__",
+        "operationsgateway_api.src.experiments.scheduler_interface.SchedulerInterface"
+        ".__init__",
         return_value=None,
     )
     @patch(
-        "operationsgateway_api.src.experiments.experiment.Experiment._get_collection_updated_date",
+        "operationsgateway_api.src.experiments.experiment.Experiment"
+        "._get_collection_updated_date",
         return_value=datetime(2023, 3, 1, 10, 0),
     )
     @patch(
@@ -40,7 +42,8 @@ class TestExperiment:
         config_scheduler_contact_date,
     )
     @patch(
-        "operationsgateway_api.src.experiments.background_scheduler_runner.BackgroundSchedulerRunner.get_next_run_task_date",
+        "operationsgateway_api.src.experiments.background_scheduler_runner"
+        ".BackgroundSchedulerRunner.get_next_run_task_date",
         return_value=datetime(2023, 3, 10, 10, 0),
     )
     @patch(
@@ -71,7 +74,8 @@ class TestExperiment:
         assert test_experiment.experiments == expected_experiments
 
     @patch(
-        "operationsgateway_api.src.experiments.scheduler_interface.SchedulerInterface.__init__",
+        "operationsgateway_api.src.experiments.scheduler_interface.SchedulerInterface"
+        ".__init__",
         return_value=None,
     )
     @patch(
@@ -85,7 +89,10 @@ class TestExperiment:
             TestExperiment.experiment_search_start_date,
             TestExperiment.experiment_search_end_date,
         )
-        parts = experiment._map_experiments_to_part_numbers(data, self.config_instrument_names[0])
+        parts = experiment._map_experiments_to_part_numbers(
+            data,
+            self.config_instrument_names[0],
+        )
         assert parts == [
             ExperimentPartMappingModel(
                 experiment_id=20310000,
@@ -110,7 +117,8 @@ class TestExperiment:
         ]
 
     @patch(
-        "operationsgateway_api.src.experiments.scheduler_interface.SchedulerInterface.__init__",
+        "operationsgateway_api.src.experiments.scheduler_interface.SchedulerInterface"
+        ".__init__",
         return_value=None,
     )
     @patch(
@@ -126,7 +134,10 @@ class TestExperiment:
         )
 
         with pytest.raises(ExperimentDetailsError):
-            experiment._map_experiments_to_part_numbers(data, self.config_instrument_names[0])
+            experiment._map_experiments_to_part_numbers(
+                data,
+                self.config_instrument_names[0],
+            )
 
     @patch(
         "operationsgateway_api.src.config.Config.config.experiments.instrument_names",
@@ -224,14 +235,22 @@ class TestExperiment:
             ),
         ],
     )
-    def test_generate_id_instrument_pairs(self, _, experiment_part_mappings, expected_pairs):
+    def test_generate_id_instrument_pairs(
+        self,
+        _,
+        experiment_part_mappings,
+        expected_pairs,
+    ):
         experiment = Experiment()
-        test_pairs = experiment._generate_id_instrument_name_pairs(experiment_part_mappings)
+        test_pairs = experiment._generate_id_instrument_name_pairs(
+            experiment_part_mappings,
+        )
         assert len(test_pairs) == len(expected_pairs)
         assert test_pairs == expected_pairs
 
     @patch(
-        "operationsgateway_api.src.experiments.experiment.Experiment._generate_id_instrument_name_pairs",
+        "operationsgateway_api.src.experiments.experiment.Experiment"
+        "._generate_id_instrument_name_pairs",
         return_value=[
             {"key": 20310000, "value": config_instrument_names[0]},
             {"key": 20310001, "value": config_instrument_names[0]},
@@ -240,7 +259,8 @@ class TestExperiment:
         ],
     )
     @patch(
-        "operationsgateway_api.src.experiments.scheduler_interface.SchedulerInterface.__init__",
+        "operationsgateway_api.src.experiments.scheduler_interface.SchedulerInterface"
+        ".__init__",
         return_value=None,
     )
     @pytest.mark.parametrize(
@@ -322,16 +342,20 @@ class TestExperiment:
             assert experiment.experiments == expected_experiments
 
     @patch(
-        "operationsgateway_api.src.experiments.scheduler_interface.SchedulerInterface.__init__",
+        "operationsgateway_api.src.experiments.scheduler_interface.SchedulerInterface"
+        ".__init__",
         return_value=None,
     )
     def test_valid_non_selected_extract_experiment_data(self, _):
         test_experiment = Experiment()
-        experiment_mocks = get_experiments_mock({18325019: [1, 2, 3, 4, 5]}, return_duplicate_parts=False)
+        experiment_mocks = get_experiments_mock(
+            {18325019: [1, 2, 3, 4, 5]},
+            return_duplicate_parts=False,
+        )
         selected_parts = [4, 5]
 
         experiment_mappings = [
-            ExperimentPartMappingModel( 
+            ExperimentPartMappingModel(
                 experiment_id=18325019,
                 parts=selected_parts,
                 instrument_name="Gemini",
@@ -339,19 +363,23 @@ class TestExperiment:
         ]
 
         test_experiment._extract_experiment_data(experiment_mocks, experiment_mappings)
-        expected_experiments = get_expected_experiment_models({18325019: selected_parts})
+        expected_experiments = get_expected_experiment_models(
+            {18325019: selected_parts},
+        )
 
         assert len(test_experiment.experiments) == len(expected_experiments)
         assert test_experiment.experiments == expected_experiments
 
     @patch(
-        "operationsgateway_api.src.experiments.experiment.Experiment._generate_id_instrument_name_pairs",
+        "operationsgateway_api.src.experiments.experiment.Experiment"
+        "._generate_id_instrument_name_pairs",
         return_value=[
             {"key": 20310000, "value": config_instrument_names[0]},
         ],
     )
     @patch(
-        "operationsgateway_api.src.experiments.scheduler_interface.SchedulerInterface.__init__",
+        "operationsgateway_api.src.experiments.scheduler_interface.SchedulerInterface"
+        ".__init__",
         return_value=None,
     )
     @pytest.mark.parametrize(
@@ -411,7 +439,8 @@ class TestExperiment:
                 experiment._extract_experiment_data(experiments, part_mappings)
 
     @patch(
-        "operationsgateway_api.src.experiments.scheduler_interface.SchedulerInterface.__init__",
+        "operationsgateway_api.src.experiments.scheduler_interface.SchedulerInterface"
+        ".__init__",
         return_value=None,
     )
     @pytest.mark.parametrize(
@@ -488,10 +517,11 @@ class TestExperiment:
                         instrument_name=self.config_instrument_names[0],
                     ),
                 ],
-            )    
+            )
 
     @patch(
-        "operationsgateway_api.src.experiments.scheduler_interface.SchedulerInterface.__init__",
+        "operationsgateway_api.src.experiments.scheduler_interface.SchedulerInterface"
+        ".__init__",
         return_value=None,
     )
     @pytest.mark.parametrize(
@@ -575,7 +605,8 @@ class TestExperiment:
         assert non_duplicate_parts == expected_non_duplicates
 
     @patch(
-        "operationsgateway_api.src.experiments.scheduler_interface.SchedulerInterface.__init__",
+        "operationsgateway_api.src.experiments.scheduler_interface.SchedulerInterface"
+        ".__init__",
         return_value=None,
     )
     @pytest.mark.parametrize(

--- a/test/experiments/test_experiment.py
+++ b/test/experiments/test_experiment.py
@@ -504,7 +504,12 @@ class TestExperiment:
         )
         assert mapping == expected_mapping
 
-    def test_invalid_get_mapping_model_by_experiment_id(self):
+    @patch(
+        "operationsgateway_api.src.experiments.scheduler_interface.SchedulerInterface"
+        ".__init__",
+        return_value=None,
+    )
+    def test_invalid_get_mapping_model_by_experiment_id(self, _):
         test_experiment = Experiment()
 
         with pytest.raises(ExperimentDetailsError):

--- a/test/experiments/test_scheduler_interface.py
+++ b/test/experiments/test_scheduler_interface.py
@@ -4,7 +4,7 @@ from operationsgateway_api.src.experiments.scheduler_interface import SchedulerI
 
 
 class TestSchedulerInterface:
-    config_instrument_names = ["Test Instrument"]
+    config_instrument_names = ["Test Instrument", "Test Instrument #2"]
     config_user_office_username = "Test Username"
     config_user_office_password = "Test Password"
     config_user_office_wsdl = "Test User Office URL"

--- a/test/experiments/test_scheduler_interface.py
+++ b/test/experiments/test_scheduler_interface.py
@@ -4,7 +4,7 @@ from operationsgateway_api.src.experiments.scheduler_interface import SchedulerI
 
 
 class TestSchedulerInterface:
-    config_instrument_name = "Test Instrument"
+    config_instrument_names = ["Test Instrument"]
     config_user_office_username = "Test Username"
     config_user_office_password = "Test Password"
     config_user_office_wsdl = "Test User Office URL"
@@ -90,8 +90,8 @@ class TestSchedulerInterface:
             assert args == expected_args
 
     @patch(
-        "operationsgateway_api.src.config.Config.config.experiments.instrument_name",
-        config_instrument_name,
+        "operationsgateway_api.src.config.Config.config.experiments.instrument_names",
+        config_instrument_names,
     )
     @patch(
         "operationsgateway_api.src.experiments.scheduler_interface.SchedulerInterface"
@@ -115,6 +115,7 @@ class TestSchedulerInterface:
 
         with patch.object(test_scheduler, "scheduler_client") as mock_client:
             test_scheduler.get_experiment_dates_for_instrument(
+                self.config_instrument_names[0],
                 date_range["startDate"],
                 date_range["endDate"],
             )


### PR DESCRIPTION
This PR allows the API to contact the Scheduler and ask for details on experiments that take place on multiple instruments where previously, only data about one instrument could be retrieved. In the config, the instruments that the API contacts are configured using by specifying the instrument names in list. In the example we currently have a single instrument but I expect that to be two in production (EA1 & EA2). 

`get_experiments_from_scheduler()` is a good place to start looking at the changes - the code now iterates through the list of configured instrument names and sends a call per instrument to the Scheduler for experiments on that instrument within the relevant start and end dates.

`_map_experiments_to_part_numbers()` now returns a list of `ExperimentPartMappingModel`, a new Pydantic model added in this PR. This replaces a list of dictionaries; the change was partly to improve code readability (as Pydantic models are easier to read/debug than dictionaries) but also because this data structure needs to keep track of which instrument the experiment is linked with. The instrument name from this data structure is used in `_generate_id_instrument_name_pairs()` - before the instrument name was just grabbed from the config but obviously this is no longer possible as there's multiple choices.

In `_generate_id_instrument_name_pairs()`, I was facing an issue where the list of experiment ID & instrument name pairs included duplicates. Converting the list of dictionaries to a set of dictionaries seems like the obvious thing to do to remove duplicates, but dictionaries aren't hashable so you can't do that straight away. Stack Overflow suggested a list comprehension which puts the data from the dictionaries into tuples (which are hashable), convert the list to a set and convert the tuples back into dictionaries. I have added comments explaining this so hopefully it's clear to someone reading the code for the first time?

A list of `ExperimentPartMappingModel`s are passed into `_extract_experiment_data()` (this used to be a list of dictionaries). As lookups cannot be performed on the model (but they could be done with dictionaries), I've added a new function, `_get_mapping_model_by_experiment_id()`. This takes a list of mapping models and an experiment ID, searching through the list until the data is found with a matching experiment ID. 

I've edited existing unit tests to cope with this change and added a new test (`test_valid_non_selected_extract_experiment_data()`) that covers a situation where `_extract_experiment_data()` might be passed some experiment parts which haven't been selected. There are also two new tests for the new `_get_mapping_model_by_experiment_id()` function.