### PR TITLE
Change JSON query parameters to use pydantic.Json

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,6 +12,6 @@ per-file-ignores =
   test/experiments/scheduler_mocking/models.py: N815
   operationsgateway_api/src/models.py: B902
 # As recommended on https://github.com/tiangolo/fastapi/discussions/7463
-extend-immutable-calls = Depends, fastapi.Depends, Query, fastapi.Query, Body, fastapi.Body, Cookie, fastapi.Cookie, Path, fastapi.Path, QueryParameterJSONParser
+extend-immutable-calls = Depends, fastapi.Depends, Query, fastapi.Query, Body, fastapi.Body, Cookie, fastapi.Cookie, Path, fastapi.Path
 # As recommended on https://github.com/pydantic/pydantic/issues/568
 classmethod-decorators = classmethod, validator, root_validator

--- a/operationsgateway_api/src/routes/common_parameters.py
+++ b/operationsgateway_api/src/routes/common_parameters.py
@@ -1,8 +1,6 @@
 from datetime import datetime
-import json
 
 from dateutil.parser import parse
-from fastapi import Request
 import pymongo
 
 from operationsgateway_api.src.exceptions import QueryParameterError
@@ -65,12 +63,3 @@ class ParameterHandler:
                 ) from exc
 
             return new_date
-
-
-class QueryParameterJSONParser:
-    def __init__(self, query_param_name: str) -> None:
-        self.query_param_name = query_param_name
-
-    def __call__(self, req: Request) -> dict:
-        query_param_value = req.query_params.get(self.query_param_name)
-        return json.loads(query_param_value) if query_param_value is not None else {}

--- a/operationsgateway_api/src/routes/records.py
+++ b/operationsgateway_api/src/routes/records.py
@@ -3,6 +3,7 @@ import logging
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Path, Query, Response
+from pydantic import Json
 
 from operationsgateway_api.src.auth.authorisation import (
     authorise_route,
@@ -11,10 +12,7 @@ from operationsgateway_api.src.auth.authorisation import (
 from operationsgateway_api.src.error_handling import endpoint_error_handling
 from operationsgateway_api.src.exceptions import QueryParameterError
 from operationsgateway_api.src.records.record import Record as Record
-from operationsgateway_api.src.routes.common_parameters import (
-    ParameterHandler,
-    QueryParameterJSONParser,
-)
+from operationsgateway_api.src.routes.common_parameters import ParameterHandler
 
 
 log = logging.getLogger()
@@ -29,7 +27,7 @@ router = APIRouter()
 )
 @endpoint_error_handling
 async def get_records(
-    conditions: dict = Depends(QueryParameterJSONParser("conditions")),
+    conditions: Json = Query({}, description="Conditions to apply to the query"),
     skip: int = Query(
         0,
         description="How many documents should be skipped before returning results",
@@ -114,7 +112,7 @@ async def get_records(
 )
 @endpoint_error_handling
 async def count_records(
-    conditions: dict = Depends(QueryParameterJSONParser("conditions")),
+    conditions: Json = Query({}, description="Conditions to apply to the query"),
     access_token: str = Depends(authorise_token),
 ):
     """
@@ -137,10 +135,15 @@ async def count_records(
 )
 @endpoint_error_handling
 async def convert_search_ranges(
-    shotnum_range: dict = Depends(  # noqa: B008
-        QueryParameterJSONParser("shotnum_range"),  # noqa: B008
+    shotnum_range: Json = Query(
+        {},
+        description='Min and max shot number range (e.g. {"min": 200, "max": 500})',
     ),
-    date_range: dict = Depends(QueryParameterJSONParser("date_range")),  # noqa: B008
+    date_range: Json = Query(
+        {},
+        description="From and to date range (e.g."
+        ' {"from": "2022-04-07 14:16:19", "to": "2022-04-07 21:00:00"})',
+    ),
     access_token: str = Depends(authorise_token),  # noqa: B008
 ):
     if date_range and shotnum_range:
@@ -163,7 +166,7 @@ async def get_record_by_id(
         ...,
         description="`_id` of the record to fetch from the database",
     ),
-    conditions: dict = Depends(QueryParameterJSONParser("conditions")),
+    conditions: Json = Query({}, description="Conditions to apply to the query"),
     truncate: Optional[bool] = Query(
         False,
         description="Parameter used for development to reduce the output of thumbnail"


### PR DESCRIPTION
In this API, we have a few query parameters where we want to accept JSON objects as inputs (which are cast to dictionaries). Up to now, we've used `fastapi.Depends` to run a custom JSON parser (`QueryParameterJSONParser`, it just runs `json.loads`) but I've recently discovered `pydantic.Json` which can do the same job for us and means we can remove the dependency injection and the `QueryParameterJSONParser` class!

I had the idea from [someone's blog](https://roman.pt/posts/fastapi-json-query/) which I haven't come across up until now.

This PR makes the change across all the query parameters where we want JSON objects as input and removes the code that's no longer needed. It looks good on the OpenAPI interface, which now suggests the input is a JSON string or an `OrderedMap` - seems to make sense.

![image](https://github.com/ral-facilities/operationsgateway-api/assets/32678030/b59d548c-b274-49f2-ac45-7c7a542e3605)
