### PR TITLE
DSEGOG-270 Fix cleanup of Echo buckets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,11 +137,11 @@ jobs:
       # until the feature is implemented
       - name: Install s3cmd
         run: sudo apt-get install -y s3cmd
-        if: steps.create_bucket.outcome == 'success'
+        if: steps.create_bucket.outcome == 'success' || failure()
       # --recursive & --force used so non-empty buckets can be deleted
       - name: Remove bucket for current job
         run: s3cmd rb --recursive --force s3://og-actions-${{ github.sha }}-${{ github.run_id }}-${{ matrix.python-version }}
-        if: steps.create_bucket.outcome == 'success'
+        if: steps.create_bucket.outcome == 'success' || failure()
 
 
   linting:


### PR DESCRIPTION
I noticed that when GitHub Actions fails, the bucket that's created at the start of the job isn't cleaned up. This was happening because the steps . This PR fixes that bug by adding an extra condition to the if statement so buckets are removed if a step fails. You can see this works on the following run where I forced a failure in the CI job - https://github.com/ral-facilities/operationsgateway-api/actions/runs/6394539896/job/17356143894