### PR TITLE
DSEGOG-280 edit pytest-async dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2471,4 +2471,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "bba3955b908c9a737ec258d3e4eca51e197c1f457310ee6290c0ab9b287c2174"
+content-hash = "c945810e3385c79511dd039b4f2a3b9980654aedcc9d702b00ae910587f0a0b1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ boto3 = "^1.26.97"
 cron-converter = "^1.0.1"
 zeep = "^4.2.1"
 httpx = "^0.23.3"
-pytest-asyncio = "^0.21.0"
 # Workaround for: https://github.com/python-poetry/poetry-plugin-export/issues/183
 # urllib3 isn't a dependency of this project, remove once the issue has been resolved
 urllib3 = ">=1.25.4,<1.27"


### PR DESCRIPTION
removed pytest-async from the dependency part of the pyproject file but kept it in the dev-dependency