### PR TITLE
DSEGOG-300 Add mongoimport back to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,17 @@ jobs:
         with:
           mongodb-version: '5.0'
 
+      # Used to install mongoimport when Ubuntu 22.04 is used, identified at https://github.com/actions/runner-images/issues/6626#issuecomment-1327744126
+      - name: Install MongoDB Database Tools
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget gnupg
+          wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | sudo apt-key add -
+          echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/5.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-5.0.list
+          sudo apt-get update
+          sudo apt-get install -y mongodb-database-tools
+
       # Read the database name from the config file and store it in an environment variable
       - name: Get database name from ci_config.yml
         run: echo "DATABASE_NAME=$(grep database_name .github/ci_config.yml | cut -d ':' -f 2 | tr -d '[:space:]')" >> $GITHUB_ENV

--- a/util/ingest_hdf.py
+++ b/util/ingest_hdf.py
@@ -126,13 +126,16 @@ if DELETE_IMAGES:
     print(f"Remove all files from the '{BUCKET_NAME}' bucket")
 
 if JSON_USERS is not None:
-    client = AsyncIOMotorClient(DATABASE_CONNECTION_URL)
-    db = client[DATABASE_NAME]
-    with open(JSON_USERS) as f:
-        users = [json.loads(line) for line in f.readlines()]
-
-    records_drop = db.users.insert_many(users)
-    print(f"Imported {len(users)} users")
+    Popen(
+        [
+            "mongoimport",
+            f"--db={DATABASE_NAME}",
+            "--collection=users",
+            "--mode=upsert",
+            f"--file={JSON_USERS}",
+        ],
+    )
+    print(f"Imported test users into database")
 
 
 def is_api_alive(host, port):


### PR DESCRIPTION
With the introduction of running tests on Python 3.10 & 3.11, Ubuntu 22.04 runners need to be used. In these runners, Ubuntu have removed mongodb from being installed in 22.04, hence the Actions runner image also not having it. We use the `supercharge/mongodb-github-action@1.7.0` action to start the database as they are "available from within the MongoDB docker container. But not directly on the 22.04 host" (https://github.com/supercharge/mongodb-github-action/issues/39#issuecomment-1328008609). 

Someone has found a solution to install `mongosh` on their CI (see https://github.com/actions/runner-images/issues/6626#issuecomment-1327744126) and I've adapted their commands to install `mongoimport` instead). I've made use of `mongoimport` in the `ingest_hdf.py` script as it serves as a good test that it works. I haven't entirely reverted Patrick's work (i.e. go back to running the command separately from the script) as I think it's better to keep it in the script (less commands that the developer needs to run) and the simulated data script will import the test users so it's nice to keep them consistent where possible.
