### PR TITLE
DSEGOG-302 Update Postman collection to use simulated CI data

### DIFF
--- a/util/og_api_postman_collection.json
+++ b/util/og_api_postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "d1e1b6a7-9aef-4d9d-82cb-3042fd13272e",
+		"_postman_id": "28dd0246-c384-4402-a74c-19993baa9a1f",
 		"name": "OperationsGateway API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "30192495"
+		"_exporter_id": "5024263"
 	},
 	"item": [
 		{
@@ -188,13 +188,13 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{og-api}}/channels/N_FLUOR_INTEGRATION",
+							"raw": "{{og-api}}/channels/PM-201-TJ-CAM-2-FWHMX",
 							"host": [
 								"{{og-api}}"
 							],
 							"path": [
 								"channels",
-								"N_FLUOR_INTEGRATION"
+								"PM-201-TJ-CAM-2-FWHMX"
 							]
 						}
 					},
@@ -216,14 +216,14 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{og-api}}/channels/summary/N_COMP_FF_E",
+							"raw": "{{og-api}}/channels/summary/PM-201-HJ-CAM-2",
 							"host": [
 								"{{og-api}}"
 							],
 							"path": [
 								"channels",
 								"summary",
-								"N_COMP_FF_E"
+								"PM-201-HJ-CAM-2"
 							]
 						}
 					},
@@ -426,7 +426,7 @@
 								},
 								{
 									"key": "skip",
-									"value": "35",
+									"value": "5",
 									"description": "Skip 35 records",
 									"disabled": true
 								},
@@ -444,56 +444,56 @@
 								},
 								{
 									"key": "conditions",
-									"value": "{\"_id\": {\"$eq\": \"20220408132830\"}}",
+									"value": "{\"_id\": {\"$eq\": \"20230604000000\"}}",
 									"description": "Return records matching the given ID",
 									"disabled": true
 								},
 								{
 									"key": "conditions",
-									"value": "{\"metadata.shotnum\": 366372}",
-									"description": "Look for records WHERE shot number is 366372",
+									"value": "{\"metadata.shotnum\": 423648000000}",
+									"description": "Look for records WHERE shot number is 423648000000",
 									"disabled": true
 								},
 								{
 									"key": "conditions",
-									"value": "{\"metadata.shotnum\": {\"$lt\": 366280}}",
-									"description": "Return records with a shot number < 366285",
+									"value": "{\"metadata.shotnum\": {\"$lt\": 423648180000}}",
+									"description": "Return records with a shot number < 423648180000",
 									"disabled": true
 								},
 								{
 									"key": "conditions",
-									"value": "{\"channels.N_COMP_FF_XPOS.data\": {\"$lt\": 310}}",
-									"description": "WHERE N_COMP_FF_XPOS's data < 310",
+									"value": "{\"channels.CM-202-CVC-CAM-2-FWHMX.data\": {\"$lt\": 50}}",
+									"description": "WHERE CM-202-CVC-CAM-2-FWHMX's data < 50",
 									"disabled": true
 								},
 								{
 									"key": "conditions",
-									"value": "{\"channels.N_COMP_SPEC_TRACE.waveform_id\": {\"$eq\": \"20220408132830_N_COMP_SPEC_TRACE\"}}",
+									"value": "{\"channels.CM-202-CVC-SP.waveform_id\": {\"$eq\": \"20230605080000_CM-202-CVC-SP\"}}",
 									"description": "Return record that matches the waveform ID",
 									"disabled": true
 								},
 								{
 									"key": "conditions",
-									"value": "{\"$or\": [{\"metadata.shotnum\": {\"$eq\": 366371}}, {\"metadata.shotnum\": {\"$gt\": 366374}}]}",
+									"value": "{\"$or\": [{\"metadata.shotnum\": {\"$eq\": 423648000000}}, {\"metadata.shotnum\": {\"$gt\": 423648038000}}]}",
 									"description": "Condition using OR and equality operators",
 									"disabled": true
 								},
 								{
 									"key": "conditions",
-									"value": "{\"$and\": [{\"metadata.timestamp\": {\"$gt\": \"2022-04-07 14:00:00\", \"$lt\": \"2022-04-08 08:00:00\"}}]}",
+									"value": "{\"$and\": [{\"metadata.timestamp\": {\"$gt\": \"2023-06-04T00:00:00\", \"$lt\": \"2023-06-04T00:30:00\"}}]}",
 									"description": "Search by date",
 									"disabled": true
 								},
 								{
 									"key": "conditions",
-									"value": "{\"channels.N_COMP_SPEC_TRACE\": {\"$exists\": true}}",
-									"description": "Return records where N_COMP_SPEC_TRACE channel exists",
+									"value": "{\"channels.CM-202-CVC-SP\": {\"$exists\": true}}",
+									"description": "Return records where CM-202-CVC-SP channel exists",
 									"disabled": true
 								},
 								{
 									"key": "conditions",
-									"value": "{\"channels.N_LEG1_GREEN_NF_YPOS.data\": {\"$exists\": false}}",
-									"description": "Return records that do not have data for the N_LEG1_GREEN_NF_YPOS channel",
+									"value": "{\"channels.FE-204-NSO-P2-CAM-2.data\": {\"$exists\": false}}",
+									"description": "Return records that do not have data for the FE-204-NSO-P2-CAM-2 channel",
 									"disabled": true
 								},
 								{
@@ -516,8 +516,8 @@
 								},
 								{
 									"key": "projection",
-									"value": "channels.N_COMP_FF_E",
-									"description": "Return N_COMP_FF_E only",
+									"value": "channels.PM-201-HJ-CRY-FAN",
+									"description": "Return PM-201-HJ-CRY-FAN only",
 									"disabled": true
 								},
 								{
@@ -528,12 +528,12 @@
 								},
 								{
 									"key": "projection",
-									"value": "channels.N_COMP_NF_IMAGE.thumbnail",
+									"value": "channels.CM-202-CVC-CAM-1.thumbnail",
 									"disabled": true
 								},
 								{
 									"key": "projection",
-									"value": "channels.N_COMP_FF_IMAGE.metadata.channel_dtype",
+									"value": "channels.CM-202-CVC-CAM-1.metadata.channel_dtype",
 									"disabled": true
 								},
 								{
@@ -583,37 +583,37 @@
 							"query": [
 								{
 									"key": "conditions",
-									"value": "{\"metadata.shotnum\": 366372}",
-									"description": "WHERE shot number = 366372",
+									"value": "{\"metadata.shotnum\": 423648180000}",
+									"description": "WHERE shot number = 423648180000",
 									"disabled": true
 								},
 								{
 									"key": "conditions",
-									"value": "{\"metadata.shotnum\": {\"$lt\": 366280}}",
-									"description": "WHERE shot number < 366280",
+									"value": "{\"metadata.shotnum\": {\"$lt\": 423648180000}}",
+									"description": "WHERE shot number < 423648180000",
 									"disabled": true
 								},
 								{
 									"key": "conditions",
-									"value": "{\"$or\": [{\"metadata.shotnum\": {\"$eq\": 366371}}, {\"metadata.shotnum\": {\"$gt\": 366372}}]}",
-									"description": "WHERE shot number = 366371 OR shot number >366372",
+									"value": "{\"$or\": [{\"metadata.shotnum\": {\"$eq\": 423648000000}}, {\"metadata.shotnum\": {\"$gt\": 423648038000}}]}",
+									"description": "WHERE shot number = 423648000000 OR shot number > 423648038000",
 									"disabled": true
 								},
 								{
 									"key": "conditions",
-									"value": "{\"channels.N_COMP_FF_XPOS.data\": {\"$lt\": 310}}",
-									"description": "WHERE N_COMP_FF_XPOS's data < 310",
+									"value": "{\"channels.CM-202-CVC-CAM-2-FWHMX.data\": {\"$lt\": 50}}",
+									"description": "WHERE N_COMP_FF_XPOS's data < 50",
 									"disabled": true
 								},
 								{
 									"key": "conditions",
-									"value": "{\"$and\": [{\"metadata.timestamp\": {\"$gt\": \"2022-04-07 14:00:00\", \"$lt\": \"2022-04-08 08:00:00\"}}]}",
+									"value": "{\"$and\": [{\"metadata.timestamp\": {\"$gt\": \"2023-06-04T00:00:00\", \"$lt\": \"2023-06-04T00:30:00\"}}]}",
 									"description": "WHERE timestamp > _ AND < _",
 									"disabled": true
 								},
 								{
 									"key": "conditions",
-									"value": "{\"channels.N_COMP_SPEC_TRACE\": {\"$exists\": true}}",
+									"value": "{\"channels.CM-202-CVC-SP\": {\"$exists\": true}}",
 									"description": "WHERE the N_COMP_SPEC_TRACE channel exists",
 									"disabled": true
 								},
@@ -644,13 +644,13 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{og-api}}/records/20220408132830",
+							"raw": "{{og-api}}/records/20230604000000",
 							"host": [
 								"{{og-api}}"
 							],
 							"path": [
 								"records",
-								"20220408132830"
+								"20230604000000"
 							],
 							"query": [
 								{
@@ -689,13 +689,13 @@
 						"method": "DELETE",
 						"header": [],
 						"url": {
-							"raw": "{{og-api}}/records/20220408142911",
+							"raw": "{{og-api}}/records/20230604000000",
 							"host": [
 								"{{og-api}}"
 							],
 							"path": [
 								"records",
-								"20220408142911"
+								"20230604000000"
 							]
 						}
 					},
@@ -717,14 +717,14 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{og-api}}/waveforms/20220408140310/N_COMP_SPEC_TRACE",
+							"raw": "{{og-api}}/waveforms/20230605080000/CM-202-CVC-SP",
 							"host": [
 								"{{og-api}}"
 							],
 							"path": [
 								"waveforms",
-								"20220408140310",
-								"N_COMP_SPEC_TRACE"
+								"20230605080000",
+								"CM-202-CVC-SP"
 							]
 						}
 					},
@@ -801,21 +801,16 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{og-api}}/images/20220408002114/N_LEG1_GREEN_NF_IMAGE",
+							"raw": "{{og-api}}/images/20230605080000/CM-202-CVC-CAM-1",
 							"host": [
 								"{{og-api}}"
 							],
 							"path": [
 								"images",
-								"20220408002114",
-								"N_LEG1_GREEN_NF_IMAGE"
+								"20230605080000",
+								"CM-202-CVC-CAM-1"
 							],
 							"query": [
-								{
-									"key": "original_image",
-									"value": "true",
-									"disabled": true
-								},
 								{
 									"key": "lower_level",
 									"value": "50",


### PR DESCRIPTION
The Postman collection still references Gemini data (through channel names, IDs etc.) and now the main branch contains the simulated data stuff, we should move to use this in the Postman collection. This PR makes all relevant changes to make that move.

To test this PR, export the Postman collection to your Postman application and test each of the endpoints with the query parameters and ensure they work. There's one query parameter that won't work in `GET /records`, specifically `{"_id": {"$eq": "20230604000000"}}`. This is due to a bug in the API. An issue has been created for this in Jira (DSEGOG - 303) so it's fine that it doesn't work, it'll be resolved when that issue is fixed.

If you haven't moved to simulated data yet, please use the following guide to get that data in your development environment: https://github.com/ral-facilities/operationsgateway-api/blob/test-data-docs/docs/test_data.md