### PR TITLE
DSEGOG-304 Add flag to allow an API instance to be pointed to https

### DIFF
--- a/.github/ci_ingest_echo_config.yml
+++ b/.github/ci_ingest_echo_config.yml
@@ -20,6 +20,7 @@ echo:
   images_bucket: og-bucket
   page_size: 1
 api:
+  https: false
   host: 127.0.0.1
   port: 8000
   username: backend

--- a/util/realistic_data/config.yml.example
+++ b/util/realistic_data/config.yml.example
@@ -21,6 +21,7 @@ echo:
   # Number of HDF files downloaded & ingested in one go
   page_size: 2
 api:
+  https: false
   host: 127.0.0.1
   port: 8000
   username: backend

--- a/util/realistic_data/ingest/config.py
+++ b/util/realistic_data/ingest/config.py
@@ -35,6 +35,7 @@ class Echo(BaseModel):
 
 
 class API(BaseModel):
+    https: bool
     host: str
     port: int
     username: str

--- a/util/realistic_data/ingest_echo_data.py
+++ b/util/realistic_data/ingest_echo_data.py
@@ -59,7 +59,8 @@ def main():
         print(f"Imported {len(users)} users")
 
     starter = APIStarter()
-    api_url = f"http://{Config.config.api.host}:{Config.config.api.port}"
+    protocol = "https" if Config.config.api.https else "http"
+    api_url = f"{protocol}://{Config.config.api.host}:{Config.config.api.port}"
     print(f"API started on {api_url}")
 
     channel_manifest = echo.download_manifest_file()


### PR DESCRIPTION
This is a small PR to pre-empt an issue that I might find when re-ingesting the data on the dev server. It allows you to work with instances of the API which use https, something which the dev server now does.

This change has only been made on the new script. It doesn't need to be made on `ingest_hdf.py` as when you don't want the script to launch an instance of the API (i.e. you want to use an instance already alive), you specify the entire URL using the `-u` option (which includes the http part)