### PR TITLE
Update export tests to account for new depth scaling

### DIFF
--- a/test/endpoints/test_export.py
+++ b/test/endpoints/test_export.py
@@ -230,11 +230,11 @@ class TestExport:
                 {
                     "20230605080000_to_20230605120000.csv": "export/"
                     "20230605080000_to_20230605120000_asc.csv",
-                    "20230605080000_FE-204-PSO-CAM-1.png": "c73838c7c437c738",
+                    "20230605080000_FE-204-PSO-CAM-1.png": "c73838c6c637c738",
                     "20230605090000_FE-204-PSO-CAM-1.png": "c73838c7c73838c7",
                     "20230605100000_FE-204-PSO-CAM-1.png": "c73838c7c73838c7",
-                    "20230605110000_FE-204-PSO-CAM-1.png": "c73938c6c0e7c738",
-                    "20230605120000_FE-204-PSO-CAM-1.png": "c4c437673839c6f8",
+                    "20230605110000_FE-204-PSO-CAM-1.png": "c73938c7c427c738",
+                    "20230605120000_FE-204-PSO-CAM-1.png": "c4c43f273838c6fc",
                 },
                 id="Zip export of main CSV with images in false colour",
             ),
@@ -785,7 +785,8 @@ class TestExport:
                     # this is an image so it needs a perceptual hash generating and
                     # comparing with what is expected
                     image = Image.open(zip_file.open(filename_in_zip))
-                    assert filepath_or_hash == str(imagehash.phash(image))
+                    hash = str(imagehash.phash(image))
+                    assert filepath_or_hash == hash, f"Difference in {filename_in_zip}"
             # diff the expected file list with that found in the zip
             # to check that all expected files were present
             files_diff = [

--- a/test/endpoints/test_export.py
+++ b/test/endpoints/test_export.py
@@ -785,8 +785,8 @@ class TestExport:
                     # this is an image so it needs a perceptual hash generating and
                     # comparing with what is expected
                     image = Image.open(zip_file.open(filename_in_zip))
-                    hash = str(imagehash.phash(image))
-                    assert filepath_or_hash == hash, f"Difference in {filename_in_zip}"
+                    phash = str(imagehash.phash(image))
+                    assert filepath_or_hash == phash, f"Difference in {filename_in_zip}"
             # diff the expected file list with that found in the zip
             # to check that all expected files were present
             files_diff = [


### PR DESCRIPTION
Following the independent merges of #104 and #103 , one the tests added in the former is not compatible with the latter. As a result, the phashes for this test need to be slightly updated.

Also added assert message (to make determining which file in the zip is the one for which the error is occuring easier).

Went through the motions to double check 20230605080000_FE-204-PSO-CAM-1.png, but did not bother for the other timestamps.

## Underlying image
![original](https://github.com/ral-facilities/operationsgateway-api/assets/61705287/fd2c8336-f3d4-4d40-857f-a510f89cf59f)
![img_bins](https://github.com/ral-facilities/operationsgateway-api/assets/61705287/3feb465e-9068-44e6-889e-6af833ed2251)
Has max pixel value of 2708 as a signed `int32`.

## Old
![20230605080000_FE-204-PSO-CAM-1_OLD](https://github.com/ral-facilities/operationsgateway-api/assets/61705287/f1d4a15c-6917-4fd4-ae23-c0c4d2a87f9d)
![dc547c71-0383-431a-962c-05f98bdf21fd](https://github.com/ral-facilities/operationsgateway-api/assets/61705287/0acbc5ac-ae23-40ea-be1e-20823a2b9405)
Input vmin, vmax: 5, 15
Scaled vmin, vmax: 1285, 3855
Subtract vmin: Max value maps to 1423 in range 0 <= x <= 2570
Scale by vmax: Max value maps to 141.7 in range 0 <= x <= 255 

## New
![20230605080000_FE-204-PSO-CAM-1](https://github.com/ral-facilities/operationsgateway-api/assets/61705287/1ca3e0e5-6990-4fd9-8fa6-25681b2da3df)
![new_bins](https://github.com/ral-facilities/operationsgateway-api/assets/61705287/c5518ed8-dd0a-4a0f-8a61-a4fc6292218e)
Input vmin, vmax: 5, 15
Scaled vmin, vmax: 1280, 4095
Subtract vmin: Max value maps to 1428 in range 0 <= x <= 2815
Scale by vmax: Max value maps to 129.8 in range 0 <= x <= 255

## Concusions
- The images themselves are indistinguishable to me.
- The number of pixels with each value graph has the same shape for before and after the scaling change, but with the new method resulting in lower pixel values.
- The artifacts at 33 etc. are present in both the before and after methods, potentially as a result of the `gray` colormap used by imsave?
- These small changes are probably the result of the minor changes in the phash. These are small (only affecting some characters), and does not even affect all images. I suspect it is only resulting in changes with this test because it uses a very narrow range between vmin/vmax, which will lead to a greater relative change to pixel values.