### PR TITLE
DSEGOG-334 Fix bug relating to experiments on ingest script

### DIFF
--- a/test/endpoints/test_get_experiments.py
+++ b/test/endpoints/test_get_experiments.py
@@ -1,20 +1,8 @@
-import os
-
 from fastapi.testclient import TestClient
-import pytest
 
 
 class TestGetExperiments:
-    @pytest.mark.skipif(
-        os.environ.get("GITHUB_ACTIONS") == "true",
-        reason="Scheduler can't be accessed on GitHub Actions so no experiments"
-        " will exist",
-    )
     def test_get_experiments(self, test_app: TestClient, login_and_get_token):
-        # There are quite a few experiments and the experiments rely on the data from
-        # the dev Scheduler (which could change). Therefore I think it's better to check
-        # just a few experiments and ensure they're correct, rather than checking every
-        # single experiment
         expected_experiments_snippet = [
             {
                 "end_date": "2023-06-21T23:59:59",

--- a/test/endpoints/test_submit_hdf.py
+++ b/test/endpoints/test_submit_hdf.py
@@ -189,7 +189,6 @@ class TestSubmitHDF:
         ],
     )
     @pytest.mark.asyncio
-    # @pytest.mark.skip
     async def test_hdf_rejects(
         self,
         data_version,
@@ -217,7 +216,6 @@ class TestSubmitHDF:
         assert test_response.status_code == 400
 
     @pytest.mark.asyncio
-    # @pytest.mark.skip
     async def test_partial_import_record_reject(
         self,
         reset_databases,
@@ -249,7 +247,6 @@ class TestSubmitHDF:
         assert test_response.status_code == 400
 
     @pytest.mark.asyncio
-    # @pytest.mark.skip
     async def test_channel_all_fail(
         self,
         reset_databases,
@@ -290,7 +287,6 @@ class TestSubmitHDF:
         assert test_response.status_code == 201
 
     @pytest.mark.asyncio
-    # @pytest.mark.skip
     async def test_channel_multiple_reject_types(
         self,
         reset_databases,

--- a/util/realistic_data/ingest_echo_data.py
+++ b/util/realistic_data/ingest_echo_data.py
@@ -27,16 +27,17 @@ def main():
     mongodb = DatabaseOperations()
     echo = S3Interface()
 
+    if Config.config.script_options.wipe_database:
+        print("Wiping database")
+        collection_names = ["channels", "experiments", "records"]
+        mongodb.drop_collections(collection_names)
+
     echo.download_experiments()
     mongodb.import_data(
         Config.config.database.remote_experiments_file_path,
         "experiments",
     )
 
-    if Config.config.script_options.wipe_database:
-        print("Wiping database")
-        collection_names = ["channels", "experiments", "records"]
-        mongodb.drop_collections(collection_names)
     if Config.config.script_options.wipe_echo:
         print(f"Wiping Echo bucket: {Config.config.echo.storage_bucket}")
         echo.delete_all()


### PR DESCRIPTION
I've fixed the bug that imports the experiments but immediately wipes the database afterwards - I've just swapped the order of these two things. I've also removed the skip on the test that wouldn't run on GitHub Actions as it is no longer relevant - the test doesn't rely on the dev scheduler so can be run on CI. I removed a couple of commented out skips too.

To test, I ran the ingest script with the `wipe_database` config option set to true and then ran the tests.