### PR TITLE
DSEGOG-337 Fix daily ingestor script trying to ingest the same file twice

### DIFF
--- a/util/realistic_data/daily_ingestor.py
+++ b/util/realistic_data/daily_ingestor.py
@@ -55,8 +55,12 @@ def main():
                 f" Response: {response_code}. Moving this file to so it can be"
                 f" investigated by a human: {failed_ingests_directory}",
             )
-
-            file_to_ingest.rename(f"{failed_ingests_directory}/{file_to_ingest.name}")
+            try:
+                file_to_ingest.rename(
+                    f"{failed_ingests_directory}/{file_to_ingest.name}",
+                )
+            except FileNotFoundError as e:
+                print(e)
 
 
 if __name__ == "__main__":

--- a/util/realistic_data/daily_ingestor.py
+++ b/util/realistic_data/daily_ingestor.py
@@ -28,11 +28,25 @@ def main():
             tzinfo=tz.gettz("Europe/London"),
         )
         for file in hdf_files
+        # Removes `in_progress/` directory from list of files
+        if file.is_file()
     }
+
     files_to_ingest = []
     for file_path, file_datetime in hdf_file_dates.items():
         if file_datetime < datetime.now(tz=tz.gettz("Europe/London")):
-            files_to_ingest.append(file_path)
+            # Move the file to an 'in progress' directory to avoid collisions with other
+            # instances of this script (i.e. cron job every minute)
+            try:
+                # Updating `file_path` so the change in directory is captured when the
+                # file is opened later in the script
+                file_path = file_path.rename(
+                    f"{hdf_data_directory}/in_progress/{file_path.name}",
+                )
+            except FileNotFoundError as e:
+                print(e)
+            else:
+                files_to_ingest.append(file_path)
 
     print("Files to ingest:")
     pprint([file.name for file in files_to_ingest])

--- a/util/realistic_data/daily_ingestor.py
+++ b/util/realistic_data/daily_ingestor.py
@@ -36,11 +36,8 @@ def main():
     current_datetime = (
         datetime.now().replace(microsecond=0).strftime(in_progress_date_format)
     )
-    Path(f"{hdf_data_directory}/in_progress_{current_datetime}").mkdir(
-        parents=True,
-        exist_ok=True,
-    )
     in_progress_dir = Path(f"{hdf_data_directory}/in_progress_{current_datetime}")
+    in_progress_dir.mkdir(parents=True, exist_ok=True)
     print(f"Created {in_progress_dir} directory")
 
     files_to_ingest = []

--- a/util/realistic_data/ingest/api_client.py
+++ b/util/realistic_data/ingest/api_client.py
@@ -44,6 +44,11 @@ class APIClient:
             return access_token, refresh_token
         except ConnectionError:
             print(f"Cannot connect with API at {self.url} for {endpoint}")
+        except requests.exceptions.InvalidSchema:
+            print(
+                "Invalid schema when logging in with requests. Have you added"
+                " http/https to the start of the API URL?",
+            )
 
     def refresh(self) -> str:
         print(f"Refresh token as '{Config.config.api.username}'")


### PR DESCRIPTION
This PR fixes an issue I've noticed on the daily ingestion of simulated data where the ingestion can't quite keep up with the cron job scheduled for every 60 seconds, thereby causing some errors when both try to ingest the same file. When there are multiple files to be ingested by `daily_ingestor.py`, the script loops through each of the files, ingesting them one at a time. Sometimes, ingesting all of the files in the list takes over 60 seconds. As such, the second execution of the script can try to ingest files that the first execution is ingesting which can throw up errors because the file can’t be found (as the first execution has finished the ingestion by that point and deletes the file).

This is resolved by creating a temporary directory where the files due to be ingested are stored so no other executions of the script can access them - kind of like a lock in a way? This directory is cleaned up and removed at the end of the script and the existing behaviour with unsuccessful ingestions hasn't changed.

I've added a few comments in the script so hopefully it makes sense. To test this, I have deployed it on the dev server and it has acted in the way that I hoped it would.