### PR TITLE
DSEGOG-327 Add `url_prefix` to API for OpenAPI docs

### DIFF
--- a/.github/ci_config.yml
+++ b/.github/ci_config.yml
@@ -3,6 +3,7 @@ app:
   port: 8000
   # API will auto-reload when changes on code files are detected
   reload: true
+  url_prefix: ""
 images:
   image_thumbnail_size: [50, 50]
   waveform_thumbnail_size: [100, 100]

--- a/operationsgateway_api/config.yml.example
+++ b/operationsgateway_api/config.yml.example
@@ -5,6 +5,7 @@ app:
   port: 8000
   # API will auto-reload when changes on code files are detected
   reload: true
+  url_prefix: ""
 images:
   # Thumbnail sizes should only ever be two element lists, of a x, y resolution
   image_thumbnail_size: [50, 50]

--- a/operationsgateway_api/src/config.py
+++ b/operationsgateway_api/src/config.py
@@ -22,6 +22,7 @@ class App(BaseModel):
     host: Optional[StrictStr] = None
     port: Optional[StrictInt] = None
     reload: Optional[StrictBool] = None
+    url_prefix: StrictStr
 
 
 class ImagesConfig(BaseModel):
@@ -102,7 +103,7 @@ class APIConfig(BaseModel):
     # When in production, there's no `app` section in the config file. A default value
     # (i.e. an empty instance of `App`) has been assigned so that if the code attempts
     # to access a config value in this section, an error is prevented
-    app: Optional[App] = App()
+    app: App
     mongodb: MongoDB
     auth: AuthConfig
     experiments: ExperimentsConfig

--- a/operationsgateway_api/src/main.py
+++ b/operationsgateway_api/src/main.py
@@ -76,6 +76,7 @@ app = FastAPI(
     description=api_description,
     default_response_class=ORJSONResponse,
     lifespan=lifespan,
+    root_path=Config.config.app.url_prefix,
 )
 
 app.add_middleware(


### PR DESCRIPTION
This PR adds the `url_prefix` to the config which sets the root path of the FastAPI `api` object created in `main.py`. This allows us to match the root path of `/api` when the API is deployed on the dev server and in turn, this means the OpenAPI interface works again on there - it gave a 404 previously.

The `app` section of this config is now mandatory so that's a minor change as a result of this PR. The example config is set to `""` because for development, the API is hosted on `/`, but for the dev server, `/api` will be set for this config option. A corresponding Ansible PR will be made to manage those types of changes.