### PR TITLE
DSEGOG-283 Fix test warnings

### DIFF
--- a/operationsgateway_api/src/models.py
+++ b/operationsgateway_api/src/models.py
@@ -49,9 +49,7 @@ class WaveformModel(BaseModel):
     path: Optional[str] = default_exclude_field
     x: Optional[Union[List[float], Any]]
     y: Optional[Union[List[float], Any]]
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @field_validator("x", "y", mode="before")
     def encode_values(cls, value):  # noqa: N805

--- a/test/records/ingestion/create_test_hdf.py
+++ b/test/records/ingestion/create_test_hdf.py
@@ -127,7 +127,7 @@ async def create_test_hdf_file(  # noqa: C901
         pm_201_fe_en.attrs.create("channel_dtype", "scalar")
         if required_attributes and "scalar" in required_attributes:
             scalar = required_attributes["scalar"]
-            if scalar["data"] != "missing":
+            if not isinstance(scalar["data"], str) or scalar["data"] != "missing":
                 pm_201_fe_en.create_dataset("data", data=(scalar["data"]))
         else:
             pm_201_fe_en.create_dataset("data", data=366272)
@@ -285,7 +285,7 @@ async def create_test_hdf_file(  # noqa: C901
             data = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.uint16)
             if required_attributes and "image" in required_attributes:
                 image = required_attributes["image"]
-                if image["data"] != "missing":
+                if not isinstance(image["data"], str) or image["data"] != "missing":
                     pm_201_fe_cam_1.create_dataset("data", data=(image["data"]))
             else:
                 pm_201_fe_cam_1.create_dataset("data", data=data)
@@ -373,12 +373,12 @@ async def create_test_hdf_file(  # noqa: C901
             if required_attributes and "waveform" in required_attributes:
                 waveform = required_attributes["waveform"]
                 if "x" in waveform:
-                    if waveform["x"] != "missing":
+                    if not isinstance(waveform["x"], str) or waveform["x"] != "missing":
                         pm_201_hj_pd.create_dataset("x", data=(waveform["x"]))
                 else:
                     pm_201_hj_pd.create_dataset("x", data=x)
                 if "y" in waveform:
-                    if waveform["y"] != "missing":
+                    if not isinstance(waveform["y"], str) or waveform["y"] != "missing":
                         pm_201_hj_pd.create_dataset("y", data=(waveform["y"]))
                 else:
                     pm_201_hj_pd.create_dataset("y", data=y)


### PR DESCRIPTION
This PR fixes the warnings that `pytest` picked up while running the tests. There were two types of warnings that got fixed:
- `PydanticDeprecatedSince20: Support for class-based config is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0.`
- `FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison`

The Pydantic warning just needed the config for `WaveformModel` migrating to the new format (I think this was just left over from when the migration previously took place. The elementwise comparison was `numpy` complaining that it was comparing a `numpy` array with a string - I added in a type check before the if statement continues with the comparison.

To test, run the tests and ensure they all pass and no warnings are shown.