### PR TITLE
DSEGOG-343 Fix black CI job not failing when it finds an issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
           key: ${{ runner.os }}-poetry-nox-black-${{ matrix.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('poetry.lock') }}
 
       - name: Run Nox black session
-        run: nox -s black
+        run: nox -s black -- --check --diff
 
 
   safety:

--- a/noxfile.py
+++ b/noxfile.py
@@ -54,10 +54,9 @@ def install_with_constraints(session, *args, **kwargs):
 
 @nox.session(reuse_venv=True)
 def black(session):
-    args = session.posargs or code_locations
-
+    args = session.posargs
     install_with_constraints(session, "black")
-    session.run("black", *args, external=True)
+    session.run("black", *code_locations, *args, external=True)
 
 
 @nox.session(reuse_venv=True)

--- a/operationsgateway_api/src/records/ingestion/channel_checks.py
+++ b/operationsgateway_api/src/records/ingestion/channel_checks.py
@@ -28,12 +28,7 @@ class ChannelChecks:
         self.ingested_image = ingested_image or []
         self.internal_failed_channel = internal_failed_channel or []
 
-        self.supported_channel_types = [
-            "scalar",
-            "image",
-            "rgb-image",
-            "waveform",
-        ]
+        self.supported_channel_types = ["scalar", "image", "rgb-image", "waveform"]
 
     def set_channels(self, manifest) -> None:
         if not manifest:


### PR DESCRIPTION
This PR fixes an issue I noticed with the CI while sorting out #140. The flake8 CI job failed and when I looked at the black job, I noticed that it reformatted some files but the job passed. This is because black "exits with code 0 unless an internal error occurred or a CLI option prompted it" (https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#the-basics).

For development, that behaviour is fine, but it's not optimal for CI - when black spots an issue and reformats the file, the job should fail. That's the behaviour I've implemented with this PR.

To test, go to your source code locally and cause an intentional formatting issue (e.g. make a line longer than 88 characters by lengthening a variable name). Then run the same command used on the CI (`nox -s black -- --check --diff`) and the command should return a non-zero code and also give you a diff of what needs to be changed.