### PR TITLE
Addmkdocs -> poetry run mkdocs in docs.yaml

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -42,4 +42,4 @@ jobs:
 
       - name: Deploy to pages
         working-directory: ./docs
-        run: mkdocs gh-deploy --force
+        run: poetry run mkdocs gh-deploy --force


### PR DESCRIPTION
Suspect the failure of this job is due to the fact [`poetry` installs to `/home/runner/.cache/pypoetry/virtualenvs`](https://github.com/ral-facilities/operationsgateway-api/actions/runs/13260880694/job/37017000914#step:7:12).

Hope that adding `poetry run` will fix this.