### PR TITLE
Implement YYYY/MM/DD/HHMMSS subdirectory structure

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,7 +8,7 @@ application-import-names = operationsgateway_api,test
 import-order-style = google
 enable-extensions=G
 per-file-ignores =
-  test/*: S101, S303
+  test/*: S101, S303, F401, F811
   test/experiments/scheduler_mocking/models.py: N815
   operationsgateway_api/src/models.py: B902
   operationsgateway_api/src/records/waveform.py: E402

--- a/operationsgateway_api/src/records/echo_interface.py
+++ b/operationsgateway_api/src/records/echo_interface.py
@@ -58,6 +58,23 @@ class EchoInterface:
             )
             raise EchoS3Error("Bucket for object storage cannot be found")
 
+    @staticmethod
+    def format_record_id(record_id: str, use_subdirectories: bool = True) -> str:
+        """
+        Historically, objects had their record_id (YYYYMMDDHHMMSS) as a directory. This
+        can lead to large (~100,000) numbers of directories in the same bucket which
+        take too long to list when debugging.
+
+        By splitting the directories into the format YYYY/MM/DD/HHMMSS, the hope is to
+        improve findability. However since migrating large amounts of data can be
+        costly, it may be practical to support both the new and old formats when
+        querying.
+        """
+        if use_subdirectories and len(record_id) > 8:
+            return f"{record_id[:4]}/{record_id[4:6]}/{record_id[6:8]}/{record_id[8:]}"
+        else:
+            return record_id
+
     def download_file_object(self, object_path: str) -> BytesIO:
         """
         Download an object from S3 using `download_fileobj()` and return a BytesIO

--- a/operationsgateway_api/src/records/export_handler.py
+++ b/operationsgateway_api/src/records/export_handler.py
@@ -317,9 +317,7 @@ class ExportHandler:
                 if channel_name in self.function_types:
                     waveform_model = channel["data"]
                 else:
-                    waveform_model = Waveform.get_waveform(
-                        Waveform.get_relative_path(record_id, channel_name),
-                    )
+                    waveform_model = Waveform.get_waveform(record_id, channel_name)
             except Exception:
                 self.errors_file_in_memory.write(
                     f"Could not find waveform for {record_id} {channel_name}\n",

--- a/operationsgateway_api/src/records/record.py
+++ b/operationsgateway_api/src/records/record.py
@@ -61,9 +61,9 @@ class Record:
         object so it can be inserted in the database as part of the record
         """
         if isinstance(data, Image):
-            _, channel_name = data.extract_metadata_from_path()
+            channel_name = data.get_channel_name_from_path()
         elif isinstance(data, Waveform):
-            channel_name = data.get_channel_name_from_id()
+            channel_name = data.get_channel_name_from_path()
 
         self.record.channels[channel_name].thumbnail = data.thumbnail
 
@@ -655,13 +655,12 @@ class Record:
             )
 
         elif channel_dtype == "waveform":
-            waveform_path = channel_value["waveform_path"]
             if "metadata" in channel_value and "x_units" in channel_value["metadata"]:
                 x_units = channel_value["metadata"]["x_units"]
             else:
                 x_units = None
 
-            waveform = Waveform.get_waveform(waveform_path)
+            waveform = Waveform.get_waveform(record_id, name)
             return WaveformVariable(waveform, x_units=x_units)
         else:
             return channel_value["data"]

--- a/operationsgateway_api/src/routes/waveforms.py
+++ b/operationsgateway_api/src/routes/waveforms.py
@@ -75,6 +75,6 @@ async def get_waveform_by_id(
 
                 return record["channels"][channel_name]["data"]
 
-    waveform_path = Waveform.get_relative_path(record_id, channel_name)
-    log.info("Getting waveform by path: %s", waveform_path)
-    return Waveform.get_waveform(waveform_path)
+    msg = "Getting waveform by record_id, channel_name: %s, %s"
+    log.info(msg, record_id, channel_name)
+    return Waveform.get_waveform(record_id, channel_name)

--- a/test/images/test_image.py
+++ b/test/images/test_image.py
@@ -133,23 +133,20 @@ class TestImage:
                 test_image.create_thumbnail()
 
     @pytest.mark.parametrize(
-        "image_path, expected_record_id, expected_channel_name",
+        ["image_path", "expected_channel_name"],
         [
             pytest.param(
                 "20220408165857/N_INP_NF_IMAGE.png",
-                "20220408165857",
                 "N_INP_NF_IMAGE",
                 id="Typical path",
             ),
             pytest.param(
                 "test/path.png",
-                "test",
                 "path",
                 id="Test path",
             ),
             pytest.param(
                 "/test/path.png",
-                "test",
                 "path",
                 id="Path starting at root level",
             ),
@@ -158,15 +155,13 @@ class TestImage:
     def test_extract_metadata(
         self,
         image_path,
-        expected_record_id,
         expected_channel_name,
     ):
         test_image = Image(
             ImageModel(path=image_path, data=np.ones(shape=(300, 300), dtype=np.uint8)),
         )
 
-        record_id, channel_name = test_image.extract_metadata_from_path()
-        assert record_id == expected_record_id
+        channel_name = test_image.get_channel_name_from_path()
         assert channel_name == expected_channel_name
 
     @patch(
@@ -357,9 +352,20 @@ class TestImage:
                     colourmap_name="jet",
                 )
 
-    def test_get_relative_path(self):
-        test_path = Image.get_relative_path("20220408165857", "N_INP_NF_IMAGE")
-        assert test_path == "20220408165857/N_INP_NF_IMAGE.png"
+    @pytest.mark.parametrize(
+        ["use_subdirectories", "path"],
+        [
+            pytest.param(False, "20220408165857/N_INP_NF_IMAGE.png"),
+            pytest.param(True, "2022/04/08/165857/N_INP_NF_IMAGE.png"),
+        ],
+    )
+    def test_get_relative_path(self, use_subdirectories: bool, path: str):
+        test_path = Image.get_relative_path(
+            "20220408165857",
+            "N_INP_NF_IMAGE",
+            use_subdirectories=use_subdirectories,
+        )
+        assert test_path == path
 
     @pytest.mark.parametrize(
         ["data", "bit_depth", "record_tuples", "dtype", "value"],

--- a/test/records/conftest.py
+++ b/test/records/conftest.py
@@ -24,9 +24,18 @@ async def remove_record_entry():
 
 
 @pytest.fixture(scope="function")
-def remove_waveform_entry():
+def remove_test_objects():
     yield
     echo = EchoInterface()
     echo.delete_file_object(
+        "images/19520605070023/test-channel-name.png",
+    )
+    echo.delete_file_object(
+        "images/1952/06/05/070023/test-channel-name.png",
+    )
+    echo.delete_file_object(
         "waveforms/19520605070023/test-channel-name.json",
+    )
+    echo.delete_file_object(
+        "waveforms/1952/06/05/070023/test-channel-name.json",
     )

--- a/test/records/test_waveform.py
+++ b/test/records/test_waveform.py
@@ -34,7 +34,7 @@ class TestWaveform:
     async def test_insert_waveform_success(
         self,
         test_waveform: WaveformModel,
-        remove_waveform_entry,
+        remove_test_objects,
     ):
         waveform_instance = Waveform(test_waveform)
         response = waveform_instance.insert_waveform()

--- a/test/records/test_waveform.py
+++ b/test/records/test_waveform.py
@@ -12,24 +12,42 @@ from operationsgateway_api.src.records.waveform import Waveform
 
 class TestWaveform:
     test_waveform = WaveformModel(
-        path="19520605070023/test-channel-name.json",
+        path="1952/06/05/070023/test-channel-name.json",
         x=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
         y=[8.0, 3.0, 6.0, 2.0, 3.0, 8.0],
     )
 
     @pytest.mark.asyncio
-    async def test_insert_waveform_success(self, remove_waveform_entry):
-        waveform_instance = Waveform(TestWaveform.test_waveform)
-        waveform_instance.insert_waveform()
+    @pytest.mark.parametrize(
+        ["test_waveform"],
+        [
+            pytest.param(test_waveform),
+            pytest.param(
+                WaveformModel(
+                    path="19520605070023/test-channel-name.json",
+                    x=test_waveform.x,
+                    y=test_waveform.y,
+                ),
+            ),
+        ],
+    )
+    async def test_insert_waveform_success(
+        self,
+        test_waveform: WaveformModel,
+        remove_waveform_entry,
+    ):
+        waveform_instance = Waveform(test_waveform)
+        response = waveform_instance.insert_waveform()
+        assert response is None
 
-        waveform = Waveform.get_waveform("19520605070023/test-channel-name.json")
+        waveform = Waveform.get_waveform("19520605070023", "test-channel-name")
 
-        assert waveform.model_dump() == TestWaveform.test_waveform.model_dump()
+        assert waveform.model_dump() == test_waveform.model_dump()
 
     @pytest.mark.asyncio
     async def test_waveform_not_found(self):
         with pytest.raises(WaveformError, match="Waveform could not be found"):
-            Waveform.get_waveform("19520605070023/test-channel-name.json")
+            Waveform.get_waveform("19520605070023", "test-channel-name.json")
 
     @pytest.mark.parametrize(
         "config_thumbnail_size",

--- a/util/move_objects.py
+++ b/util/move_objects.py
@@ -9,7 +9,15 @@ from operationsgateway_api.src.records.echo_interface import EchoInterface
 from operationsgateway_api.src.records.image import Image
 from operationsgateway_api.src.records.waveform import Waveform
 
-parser = argparse.ArgumentParser()
+description = (
+    "Utility script for moving objects stored in echo from their actual location to a "
+    "new, preferred path. For one or more records, every channel storing data in an "
+    "old style location is fetched. This data is then copied from to a location using "
+    "the current preferred path style, and the record in the database is updated. "
+    "Finally, data in the old location is deleted. Renaming buckets is not possible, "
+    "so the data must be copied then deleted at the original location."
+)
+parser = argparse.ArgumentParser(description=description)
 parser.add_argument(
     "-u",
     "--url",

--- a/util/move_objects.py
+++ b/util/move_objects.py
@@ -1,0 +1,101 @@
+import argparse
+import asyncio
+
+from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
+import pymongo
+
+from operationsgateway_api.src.config import Config
+from operationsgateway_api.src.records.echo_interface import EchoInterface
+from operationsgateway_api.src.records.image import Image
+from operationsgateway_api.src.records.waveform import Waveform
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "-u",
+    "--url",
+    type=str,
+    help="URL of database",
+    default="mongodb://localhost:27017",
+)
+parser.add_argument(
+    "-n",
+    "--database-name",
+    type=str,
+    help="Name of database",
+    default="opsgateway",
+)
+parser.add_argument(
+    "-l",
+    "--limit",
+    type=int,
+    help="Number of records to move data for",
+    default=1,
+)
+
+args = parser.parse_args()
+DATABASE_CONNECTION_URL = args.url
+DATABASE_NAME = args.database_name
+BUCKET_NAME = Config.config.echo.bucket_name
+LIMIT = args.limit
+
+
+async def move_object(
+    echo_interface: EchoInterface,
+    records: AsyncIOMotorCollection,
+    channel_name: str,
+    path_key: str,
+    file_extension: str,
+    controller: Image | Waveform,
+) -> None:
+    field = f"channels.{channel_name}.{path_key}"
+    regex_value = r"^\d{14}\/" + channel_name + r"\." + file_extension + r"$"
+    regex_filter = {field: {"$regex": regex_value}}
+    cursor = records.find(filter=regex_filter, projection=[field], limit=LIMIT)
+    async for model in cursor:
+        record_id = model["_id"]
+        old_path = model["channels"][channel_name][path_key]
+        old_full_path = controller.get_full_path(relative_path=old_path)
+        new_path = controller.get_relative_path(record_id, channel_name, True)
+        full_new_path = controller.get_full_path(new_path)
+
+        copy_source = {"Bucket": Config.config.echo.bucket_name, "Key": old_full_path}
+        update = {"$set": {f"channels.{channel_name}.{path_key}": new_path}}
+        delete = {"Objects": [{"Key": old_full_path}]}
+        echo_interface.bucket.copy(CopySource=copy_source, Key=full_new_path)
+        records.update_one(filter={"_id": record_id}, update=update)
+        echo_interface.bucket.delete_objects(Delete=delete)
+
+
+async def main():
+    echo_interface = EchoInterface()
+    client = AsyncIOMotorClient(DATABASE_CONNECTION_URL)
+    db = client[DATABASE_NAME]
+    channels_manifests = db.get_collection("channels")
+    records = db.get_collection("records")
+    sort = [("_id", pymongo.DESCENDING)]
+    channels_manifest = await channels_manifests.find_one(sort=sort)
+    for channel_name, channel_model in channels_manifest["channels"].items():
+        if channel_model["type"] == "image":
+            print("Processing image channel:", channel_name)
+            await move_object(
+                echo_interface,
+                records,
+                channel_name,
+                path_key="image_path",
+                file_extension="png",
+                controller=Image,
+            )
+        elif channel_model["type"] == "waveform":
+            print("Processing waveform channel:", channel_name)
+            await move_object(
+                echo_interface,
+                records,
+                channel_name,
+                path_key="waveform_path",
+                file_extension="json",
+                controller=Waveform,
+            )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
- New images/waveforms created in Echo will use a `YYYY/MM/DD/HHMMSS` (sub)directory structure, to avoid the current situation of having ~100,000 objects in the `image` and `waveform` directories, which made listing practically impossible when e.g. debugging with `s3cmd`.
- Minor name changes/refactors to some existing methods which extracted channel_name from the image/waveform_path so that they were more consistent and intuitively named across both classes.
- In `get_image` and `get_waveform`, first try the new subdirectory structure and if that fails, default to the old structure before actually failing. This allows us to use the new structure going forward, without needing to migrate existing data.
- Minor updates to relevant tests (coverage might need checking - locally I had a mix of "old" and "new" paths in my bucket but if the CI ingests from scratch it will only have "new" paths, so coverage might be lower)
- Added a basic script with will search Mongo, find "old" data paths, copy the waveform/image to its new location, update Mongo and delete the old object. When I tested this locally however, it took the best part of a minute to move one record. Kevin has said their are around 150,000 records on the dev server. It might be that by chance my record had a lot of images, but if every record took as long as that it could be 100 days to migrate the data to the new structure. Ideally I think it would be better to have the backwards compatibility for the old path, which we can deprecate at a later date if needed then try to migrate all the historic data. But the script is included for completeness.