### PR TITLE
Support for vectors

### DIFF
--- a/.github/ci_config.yml
+++ b/.github/ci_config.yml
@@ -15,6 +15,8 @@ images:
 waveforms:
   thumbnail_size: [100, 100]
   line_width: 0.3
+vectors:
+  thumbnail_size: [100, 100]
 echo:
   url: http://127.0.0.1:9000
   username: operationsgateway

--- a/operationsgateway_api/config.yml.example
+++ b/operationsgateway_api/config.yml.example
@@ -19,6 +19,8 @@ images:
 waveforms:
   thumbnail_size: [100, 100]
   line_width: 0.3
+vectors:
+  thumbnail_size: [100, 100]
 echo:
   url: https://s3.echo.stfc.ac.uk
   username: username

--- a/operationsgateway_api/src/config.py
+++ b/operationsgateway_api/src/config.py
@@ -44,6 +44,10 @@ class WaveformsConfig(BaseModel):
     line_width: float
 
 
+class VectorsConfig(BaseModel):
+    thumbnail_size: tuple[int, int]
+
+
 class EchoConfig(BaseModel):
     url: StrictStr
     username: StrictStr
@@ -116,6 +120,7 @@ class APIConfig(BaseModel):
     experiments: ExperimentsConfig
     images: ImagesConfig
     waveforms: WaveformsConfig
+    vectors: VectorsConfig
     echo: EchoConfig
     export: ExportConfig
 

--- a/operationsgateway_api/src/exceptions.py
+++ b/operationsgateway_api/src/exceptions.py
@@ -129,6 +129,12 @@ class WaveformError(ApiError):
         self.status_code = 500
 
 
+class VectorError(ApiError):
+    def __init__(self, msg="Vector error", *args, **kwargs):
+        super().__init__(msg, *args, **kwargs)
+        self.status_code = 500
+
+
 class UserError(ApiError):
     def __init__(self, msg="User error", *args, **kwargs):
         super().__init__(msg, *args, **kwargs)

--- a/operationsgateway_api/src/models.py
+++ b/operationsgateway_api/src/models.py
@@ -68,6 +68,11 @@ class WaveformModel(BaseModel):
             return value
 
 
+class VectorModel(BaseModel):
+    path: str | Any | None
+    data: list[float] | Any | None
+
+
 class ImageChannelMetadataModel(BaseModel):
     channel_dtype: Optional[Union[str, Any]]
     exposure_time_s: Optional[Union[float, Any]] = None
@@ -129,6 +134,18 @@ class WaveformChannelModel(BaseModel):
     waveform_path: Optional[Union[str, Any]]
 
 
+class VectorChannelMetadataModel(BaseModel):
+    channel_dtype: Literal["vector"] | Any | None = "vector"
+    units: str | Any | None = None
+    labels: list[str] | Any | None = None
+
+
+class VectorChannelModel(BaseModel):
+    metadata: VectorChannelMetadataModel
+    thumbnail: bytes | Any | None = None
+    vector_path: str | Any | None = None
+
+
 class RecordMetadataModel(BaseModel):
     epac_ops_data_version: Optional[Any] = None
     shotnum: Optional[int] = None
@@ -142,7 +159,12 @@ class RecordModel(BaseModel):
     metadata: RecordMetadataModel
     channels: Dict[
         str,
-        Union[ImageChannelModel, ScalarChannelModel, WaveformChannelModel],
+        Union[
+            ImageChannelModel,
+            ScalarChannelModel,
+            WaveformChannelModel,
+            VectorChannelModel,
+        ],
     ]
 
 
@@ -175,7 +197,10 @@ class ChannelModel(BaseModel):
 
     name: str
     path: str
-    type_: Optional[Literal["scalar", "image", "waveform"]] = Field(None, alias="type")
+    type_: Literal["scalar", "image", "waveform", "raw_file"] | None = Field(
+        None,
+        alias="type",
+    )
 
     # Should the value be displayed as it is stored or be shown in x10^n format
     notation: Optional[Literal["scientific", "normal"]] = None

--- a/operationsgateway_api/src/records/echo_interface.py
+++ b/operationsgateway_api/src/records/echo_interface.py
@@ -26,6 +26,12 @@ class EchoInterface:
     def __init__(self) -> None:
         log.debug("Creating S3 resource to connect to Echo")
         try:
+            self.client = boto3.client(
+                "s3",
+                endpoint_url=Config.config.echo.url,
+                aws_access_key_id=Config.config.echo.access_key,
+                aws_secret_access_key=Config.config.echo.secret_key,
+            )
             self.resource = boto3.resource(
                 "s3",
                 endpoint_url=Config.config.echo.url,
@@ -57,6 +63,22 @@ class EchoInterface:
                 Config.config.echo.bucket_name,
             )
             raise EchoS3Error("Bucket for object storage cannot be found")
+
+    def head_object(self, object_path: str) -> bool:
+        """
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/head_object.html
+        Uses the head operation to check the existence of an object without downloading
+        it.
+        """
+        log.info("Head object in Echo: %s", object_path)
+        try:
+            self.client.head_object(
+                Bucket=Config.config.echo.bucket_name,
+                Key=object_path,
+            )
+            return True
+        except ClientError:
+            return False
 
     def download_file_object(self, object_path: str) -> BytesIO:
         """

--- a/operationsgateway_api/src/records/export_handler.py
+++ b/operationsgateway_api/src/records/export_handler.py
@@ -9,6 +9,7 @@ from operationsgateway_api.src.functions.type_transformer import TypeTransformer
 from operationsgateway_api.src.models import ChannelManifestModel
 from operationsgateway_api.src.records.image import Image
 from operationsgateway_api.src.records.record import Record
+from operationsgateway_api.src.records.vector import Vector
 from operationsgateway_api.src.records.waveform import Waveform
 
 
@@ -32,6 +33,8 @@ class ExportHandler:
         export_images: bool,
         export_waveform_csvs: bool,
         export_waveform_images: bool,
+        export_vector_csvs: bool,
+        export_vector_images: bool,
     ) -> None:
         """
         Store all of the information that needs to be processed during the export
@@ -47,6 +50,8 @@ class ExportHandler:
         self.export_images = export_images
         self.export_waveform_csvs = export_waveform_csvs
         self.export_waveform_images = export_waveform_images
+        self.export_vector_csvs = export_vector_csvs
+        self.export_vector_images = export_vector_images
 
         self.record_ids = []
         self.errors_file_in_memory = io.StringIO()
@@ -167,7 +172,7 @@ class ExportHandler:
                 # image and waveform data will be exported to separate files so will not
                 # have values put in the main csv file
                 channel_type = self._get_channel_type(channel_name)
-                if channel_type not in ["image", "waveform"]:
+                if channel_type not in ["image", "waveform", "vector"]:
                     line = self._add_value_to_csv_line(line, channel_name)
             else:
                 # this must be a "metadata" channel
@@ -228,6 +233,12 @@ class ExportHandler:
                 x_units,
                 y_units,
             )
+        elif channel_type == "vector":
+            log.info("Channel %s is a vector", channel_name)
+            labels = None
+            if "metadata" in channel and "labels" in channel["metadata"]:
+                labels = channel["metadata"]["labels"]
+            await self._add_vector_to_zip(record_data, record_id, channel_name, labels)
         # process a scalar channel
         else:
             log.info("Channel %s is a scalar", channel_name)
@@ -351,6 +362,63 @@ class ExportHandler:
                     f"{record_id}_{channel_name}.png",
                     waveform_png_bytes,
                 )
+                self._check_zip_file_size()
+
+    async def _add_vector_to_zip(
+        self,
+        record_data: dict,
+        record_id: str,
+        channel_name: str,
+        labels: list[str] | None,
+    ) -> None:
+        """
+        Get the arrays of x and y values for a waveform and then either write them to a
+        CSV file or create a rendered image of the waveform (or both) and add the
+        created file(s) to the zip file being created ready for download.
+        """
+        try:
+            # first check that there should be a vector to process
+            record_data["channels"][channel_name]
+        except KeyError:
+            # there is no entry for this channel in the record
+            # so there is no vector to process
+            return
+
+        if self.export_vector_csvs or self.export_vector_images:
+            log.info(
+                "Getting vector to add to zip: %s %s",
+                record_id,
+                channel_name,
+            )
+            try:
+                # TODO functions support?
+                vector_model = await Vector.get_vector(
+                    Vector.get_relative_path(record_id, channel_name),
+                )
+            except Exception:
+                self.errors_file_in_memory.write(
+                    f"Could not find vector for {record_id} {channel_name}\n",
+                )
+                # no point trying to process the vector so return at this point
+                return
+
+            if self.export_vector_csvs:
+                string_io = io.StringIO()
+                if labels:
+                    for label, value in zip(labels, vector_model.data, strict=True):
+                        string_io.write(f"{label},{value}\n")
+                else:
+                    for value in vector_model.data:
+                        string_io.write(f"{value}\n")
+
+                data = string_io.getvalue()
+                self.zip_file.writestr(f"{record_id}_{channel_name}.csv", data)
+                self._check_zip_file_size()
+
+            if self.export_vector_images:
+                vector = Vector(vector_model)
+                vector_image = vector.get_fullsize_png(labels)
+                self.zip_file.writestr(f"{record_id}_{channel_name}.png", vector_image)
                 self._check_zip_file_size()
 
     def _add_main_csv_file_to_zip(self):

--- a/operationsgateway_api/src/records/ingestion/channel_checks.py
+++ b/operationsgateway_api/src/records/ingestion/channel_checks.py
@@ -1,10 +1,18 @@
 import logging
-from typing import Dict, List
+from types import NoneType
+from typing import Any, Dict, List
 
 import numpy as np
+from pydantic import BaseModel
 
 from operationsgateway_api.src.exceptions import ChannelManifestError
-from operationsgateway_api.src.models import ChannelModel
+from operationsgateway_api.src.models import (
+    ChannelModel,
+    ImageModel,
+    VectorChannelMetadataModel,
+    VectorModel,
+    WaveformModel,
+)
 
 
 log = logging.getLogger()
@@ -14,9 +22,10 @@ class ChannelChecks:
     def __init__(
         self,
         ingested_record=None,
-        ingested_waveform=None,
-        ingested_image=None,
-        internal_failed_channel=None,
+        ingested_waveforms=None,
+        ingested_images=None,
+        ingested_vectors=None,
+        internal_failed_channels=None,
     ):
         """
         This class is instantiated using everything from hdf_handler
@@ -24,11 +33,18 @@ class ChannelChecks:
         hdf_handler already
         """
         self.ingested_record = ingested_record or []
-        self.ingested_waveform = ingested_waveform or []
-        self.ingested_image = ingested_image or []
-        self.internal_failed_channel = internal_failed_channel or []
+        self.ingested_waveforms = ingested_waveforms or []
+        self.ingested_images = ingested_images or []
+        self.ingested_vectors = ingested_vectors or []
+        self.internal_failed_channels = internal_failed_channels or []
 
-        self.supported_channel_types = ["scalar", "image", "rgb-image", "waveform"]
+        self.supported_channel_types = [
+            "scalar",
+            "image",
+            "rgb-image",
+            "waveform",
+            "vector",
+        ]
 
     def set_channels(self, manifest) -> None:
         if not manifest:
@@ -55,7 +71,7 @@ class ChannelChecks:
             for response in internal_failed_channel:
                 for reason in response.values():
                     for accepted_reason in accept_list:
-                        if reason == accepted_reason:
+                        if reason.startswith(accepted_reason):
                             rejected_channels.append(response)
         return rejected_channels
 
@@ -108,7 +124,7 @@ class ChannelChecks:
 
         rejected_channels = self._merge_internal_failed(
             rejected_channels,
-            self.internal_failed_channel,
+            self.internal_failed_channels,
             [
                 "channel_dtype attribute is missing",
                 "channel_dtype has wrong data type or its value is unsupported",
@@ -116,6 +132,19 @@ class ChannelChecks:
         )
 
         return rejected_channels
+
+    @staticmethod
+    def _find_path(
+        ingested_list: list[ImageModel | WaveformModel | VectorModel],
+        path: str,
+    ) -> ImageModel | WaveformModel | VectorModel | None:
+        """
+        Returns the model from ingested_list with the specified path, or None if not
+        found.
+        """
+        for ingested_model in ingested_list:
+            if ingested_model.path == path:
+                return ingested_model
 
     def required_attribute_checks(self):
         """
@@ -126,29 +155,21 @@ class ChannelChecks:
         the reason they failed to return to the used as an output dict
         """
         ingested_channels = self.ingested_record.channels
-        ingested_waveform = self.ingested_waveform
-        ingested_image = self.ingested_image
 
         rejected_channels = []
         for key, value in ingested_channels.items():
             if value.metadata.channel_dtype == "image":
-                image = None
-                for images in ingested_image:
-                    if images.path == value.image_path:
-                        image = images
-                        continue
-
+                image = ChannelChecks._find_path(self.ingested_images, value.image_path)
                 if not isinstance(image.data, np.ndarray):
                     rejected_channels.append(
                         {key: "data attribute has wrong datatype, should be ndarray"},
                     )
 
             if value.metadata.channel_dtype == "waveform":
-                matching_waveform = None
-                for waveform in ingested_waveform:
-                    if waveform.path == value.waveform_path:
-                        matching_waveform = waveform
-                        continue
+                matching_waveform = ChannelChecks._find_path(
+                    self.ingested_waveforms,
+                    value.waveform_path,
+                )
 
                 if not isinstance(matching_waveform.x, list) or not all(
                     isinstance(element, float) for element in matching_waveform.x
@@ -164,9 +185,21 @@ class ChannelChecks:
                         {key: "y attribute must be a list of floats"},
                     )
 
+            elif value.metadata.channel_dtype == "vector":
+                vector = ChannelChecks._find_path(
+                    ingested_list=self.ingested_vectors,
+                    path=value.vector_path,
+                )
+                if not (
+                    isinstance(vector.data, list)
+                    and all(isinstance(e, float) for e in vector.data)
+                ):
+                    message = "data attribute has wrong datatype, should be list[float]"
+                    rejected_channels.append({key: message})
+
         rejected_channels = self._merge_internal_failed(
             rejected_channels,
-            self.internal_failed_channel,
+            self.internal_failed_channels,
             [
                 "data attribute is missing",
                 "data has wrong datatype",
@@ -259,6 +292,108 @@ class ChannelChecks:
 
         return rejected_channels
 
+    @staticmethod
+    def _ensure_dict(possible_model: dict | BaseModel) -> dict:
+        """
+        If possible_model isn't a dict, calls model_dump so that a dict is always
+        returned.
+        """
+        if not isinstance(possible_model, dict):
+            return possible_model.model_dump()
+        else:
+            return possible_model
+
+    @staticmethod
+    def _check_type(
+        channel_name: str,
+        attribute_name: str,
+        value_dict: dict[str, Any],
+        rejected_channels: list[dict[str, str]],
+        accepted_types: tuple[type],
+    ) -> Any:
+        """
+        Modifies rejected_channels in place with a new message if attribute name is
+        specified and the value is not of one of the accepted_types or NoneType.
+        """
+        if attribute_name in value_dict:
+            attribute = value_dict[attribute_name]
+            if not isinstance(attribute, (NoneType, *accepted_types)):
+                message = f"{attribute_name} attribute has wrong datatype"
+                rejected_channels.append({channel_name: message})
+
+            return attribute
+
+    @staticmethod
+    def _check_str(
+        channel_name: str,
+        attribute_name: str,
+        value_dict: dict[str, Any],
+        rejected_channels: list[dict[str, str]],
+    ) -> None:
+        """
+        Modifies rejected_channels in place with a new message if attribute name is
+        specified and the value is not a str.
+        """
+        ChannelChecks._check_type(
+            channel_name,
+            attribute_name,
+            value_dict,
+            rejected_channels,
+            (str,),
+        )
+
+    @staticmethod
+    def _check_list(
+        channel_name: str,
+        attribute_name: str,
+        value_dict: dict[str, Any],
+        rejected_channels: list[dict[str, str]],
+        element_type: type,
+        length: int,
+    ) -> None:
+        """
+        Modifies rejected_channels in place with a new message if attribute name is
+        specified and the value is not a list. All elements in the list are checked
+        against element_type, and it must have the specified length.
+        """
+        attribute = ChannelChecks._check_type(
+            channel_name,
+            attribute_name,
+            value_dict,
+            rejected_channels,
+            (list,),
+        )
+        if not all(isinstance(e, element_type) for e in attribute):
+            message = f"{attribute_name} attribute has wrong datatype"
+            rejected_channels.append({channel_name: message})
+        if len(attribute) != length:
+            message = f"{attribute_name} attribute has wrong length"
+            rejected_channels.append({channel_name: message})
+
+    @classmethod
+    def vector_metadata_checks(
+        cls,
+        key: str,
+        value_dict: dict | VectorChannelMetadataModel,
+        rejected_channels: list[dict[str, str]],
+        length: int,
+    ) -> list[dict[str, str]]:
+        value_dict = ChannelChecks._ensure_dict(value_dict)
+        ChannelChecks._check_str(
+            channel_name=key,
+            attribute_name="units",
+            value_dict=value_dict,
+            rejected_channels=rejected_channels,
+        )
+        ChannelChecks._check_list(
+            key,
+            "labels",
+            value_dict,
+            rejected_channels,
+            str,
+            length,
+        )
+
     def optional_dtype_checks(self):
         """
         Checks if the optional attributes of each channel has the correct datatype
@@ -303,6 +438,18 @@ class ChannelChecks:
                         {key: "y_units attribute has wrong datatype"},
                     )
 
+            elif value.metadata.channel_dtype == "vector":
+                vector = ChannelChecks._find_path(
+                    ingested_list=self.ingested_vectors,
+                    path=value.vector_path,
+                )
+                rejected_channels = self.vector_metadata_checks(
+                    key,
+                    value.metadata,
+                    rejected_channels,
+                    len(vector.data),
+                )
+
         return rejected_channels
 
     def _waveform_dataset_check(self, rejected_channels, value, key, letter):
@@ -332,15 +479,13 @@ class ChannelChecks:
         the reason they failed to return to the used as an output dict
         """
         ingested_channels = (self.ingested_record).channels
-        ingested_waveform = self.ingested_waveform
-        ingested_image = self.ingested_image
 
         rejected_channels = []
 
         for key, value in ingested_channels.items():
             if value.metadata.channel_dtype == "image":
                 data = None
-                for image in ingested_image:
+                for image in self.ingested_images:
                     if image.path == value.image_path:
                         data = image.data
                         continue
@@ -363,7 +508,7 @@ class ChannelChecks:
             if value.metadata.channel_dtype == "waveform":
                 matching_waveform = None
 
-                for waveform in ingested_waveform:
+                for waveform in self.ingested_waveforms:
                     if waveform.path == value.waveform_path:
                         matching_waveform = waveform
                         continue
@@ -386,7 +531,7 @@ class ChannelChecks:
 
         rejected_channels = self._merge_internal_failed(
             rejected_channels,
-            self.internal_failed_channel,
+            self.internal_failed_channels,
             [
                 "data attribute is missing",
                 "data has wrong datatype",
@@ -412,7 +557,7 @@ class ChannelChecks:
 
         rejected_channels = self._merge_internal_failed(
             rejected_channels,
-            self.internal_failed_channel,
+            self.internal_failed_channels,
             [
                 "unexpected group or dataset in channel group",
             ],
@@ -473,7 +618,7 @@ class ChannelChecks:
 
         rejected_channels = self._merge_internal_failed(
             rejected_channels,
-            self.internal_failed_channel,
+            self.internal_failed_channels,
             [
                 "Channel name is not recognised (does not appear in manifest)",
             ],

--- a/operationsgateway_api/src/records/ingestion/partial_import_checks.py
+++ b/operationsgateway_api/src/records/ingestion/partial_import_checks.py
@@ -4,10 +4,12 @@ from operationsgateway_api.src.exceptions import EchoS3Error, RejectRecordError
 from operationsgateway_api.src.models import (
     ImageChannelModel,
     RecordModel,
+    VectorChannelModel,
     WaveformChannelModel,
 )
 from operationsgateway_api.src.records.echo_interface import EchoInterface
 from operationsgateway_api.src.records.image import Image
+from operationsgateway_api.src.records.vector import Vector
 from operationsgateway_api.src.records.waveform import Waveform
 
 
@@ -87,7 +89,10 @@ class PartialImportChecks:
             )
             raise RejectRecordError("inconsistent metadata")
 
-    def channel_checks(self):
+    def channel_checks(
+        self,
+        channel_dict: dict[str, list[str] | dict[str, str]],
+    ) -> dict[str, list[str] | dict[str, str]]:
         """
         Checks if any of the incoming channels exist in the stored record. If the
         channels exist, they're rejected, otherwise they become an accepted channel.
@@ -107,10 +112,13 @@ class PartialImportChecks:
             if channel_name in stored_channels:
                 if isinstance(channel_model, ImageChannelModel):
                     path = Image.get_full_path(channel_model.image_path)
-                    object_stored = self._is_image_or_waveform_stored(path)
+                    object_stored = self.echo.head_object(path)
                 elif isinstance(channel_model, WaveformChannelModel):
                     path = Waveform.get_full_path(channel_model.waveform_path)
-                    object_stored = self._is_image_or_waveform_stored(path)
+                    object_stored = self.echo.head_object(path)
+                elif isinstance(channel_model, VectorChannelModel):
+                    path = Vector.get_full_path(channel_model.vector_path)
+                    object_stored = self.echo.head_object(path)
                 else:
                     object_stored = True
                 if object_stored:
@@ -122,12 +130,16 @@ class PartialImportChecks:
             else:
                 accepted_channels.append(channel_name)
 
-        channel_response = {
+        log.info("existent record found")
+        for key, value in channel_dict["rejected_channels"].items():
+            rejected_channels[key] = value
+            if key in accepted_channels:
+                accepted_channels.remove(key)
+
+        return {
             "accepted_channels": accepted_channels,
             "rejected_channels": rejected_channels,
         }
-
-        return channel_response
 
     def _is_image_or_waveform_stored(self, path: str) -> bool:
         """

--- a/operationsgateway_api/src/records/vector.py
+++ b/operationsgateway_api/src/records/vector.py
@@ -1,0 +1,133 @@
+import base64
+from io import BytesIO
+import json
+import logging
+
+from botocore.exceptions import ClientError
+from matplotlib import pyplot as plt
+
+from operationsgateway_api.src.config import Config
+from operationsgateway_api.src.exceptions import (
+    EchoS3Error,
+    VectorError,
+)
+from operationsgateway_api.src.models import VectorModel
+from operationsgateway_api.src.records.echo_interface import EchoInterface
+
+
+log = logging.getLogger()
+
+
+class Vector:
+    echo_prefix = "vectors"
+
+    def __init__(self, vector: VectorModel) -> None:
+        self.vector = vector
+        self.thumbnail = None
+
+    @staticmethod
+    async def get_vector(record_id: str, channel_name: str) -> VectorModel:
+        """
+        Get vector data from storage and return it as a VectorModel. If no vector can be
+        found, a VectorError will be raised.
+        """
+        log.info("Retrieving vector and returning a VectorModel")
+        echo = EchoInterface()
+
+        try:
+            relative_path = Vector.get_relative_path(record_id, channel_name)
+            full_path = Vector.get_full_path(relative_path)
+            bytes_io = echo.download_file_object(full_path)
+            vector_dict = json.loads(bytes_io.getvalue().decode())
+            return VectorModel(**vector_dict)
+        except (ClientError, EchoS3Error) as exc:
+            log.error("Vector could not be found: %s", relative_path)
+            msg = f"Vector could not be found on object storage: {relative_path}"
+            raise VectorError(msg) from exc
+
+    @staticmethod
+    def get_relative_path(record_id: str, channel_name: str) -> str:
+        """
+        Returns a relative path given a record id and channel name. The path is relative
+        to the base directory.
+        """
+        return f"{record_id}/{channel_name}"
+
+    @staticmethod
+    def get_full_path(relative_path: str) -> str:
+        """
+        Returns the full path by adding the storage base directory to the start of the
+        path. The full path does not include the bucket name.
+        """
+        return f"{Vector.echo_prefix}/{relative_path}"
+
+    def get_channel_name_from_path(self) -> str:
+        """
+        Get the channel name from the storage path.
+        """
+        return self.vector.path.split("/")[-1].split(".json")[0]
+
+    def insert_vector(self) -> str | None:
+        """
+        Upload the bytes of this vector to storage. Returns the channel name if the
+        upload fails.
+        """
+        log.info("Storing vector: %s", self.vector.path)
+        echo = EchoInterface()
+        try:
+            bytes_io = BytesIO(self.vector.model_dump_json(indent=2).encode())
+            echo.upload_file_object(bytes_io, Vector.get_full_path(self.vector.path))
+            return  # Successful upload
+        except EchoS3Error:
+            # Extract the channel name and propagate it
+            channel_name = self.get_channel_name_from_path()
+            log.exception(
+                "Failed to upload vector for channel '%s'",
+                channel_name,
+            )
+            return channel_name
+
+    def create_thumbnail(self) -> None:
+        """
+        Create a thumbnail of the vector data and store it in this object.
+        """
+        with BytesIO() as bytes_io:
+            thumbnail_size = Config.config.vectors.thumbnail_size
+            # 1 in figsize = 100px
+            plt.figure(figsize=(thumbnail_size[0] / 100, thumbnail_size[1] / 100))
+            plt.xticks([])
+            plt.yticks([])
+            plt.bar(range(len(self.vector.data)), self.vector.data)
+            plt.axis("off")
+            plt.axhline(c="black")
+            plt.box(False)
+            plt.savefig(
+                bytes_io,
+                format="PNG",
+                bbox_inches="tight",
+                pad_inches=0,
+                dpi=130,
+            )
+            plt.clf()
+            plt.close()
+            self.thumbnail = base64.b64encode(bytes_io.getvalue())
+
+    def get_fullsize_png(self, labels: list[str] | None) -> bytes:
+        """
+        Create a full size image of the vector data and return it.
+        """
+        if not labels:
+            labels = range(len(self.vector.data))
+
+        with BytesIO() as bytes_io:
+            plt.figure(figsize=(8, 6))
+            plt.bar(labels, self.vector.data)
+            plt.savefig(
+                bytes_io,
+                format="PNG",
+                bbox_inches="tight",
+                pad_inches=0.1,
+                dpi=130,
+            )
+            plt.clf()
+            return bytes_io.getvalue()

--- a/operationsgateway_api/src/routes/export.py
+++ b/operationsgateway_api/src/routes/export.py
@@ -105,6 +105,14 @@ async def export_records(
         False,
         description="Whether to export rendered images of the waveforms",
     ),
+    export_vector_csvs: bool = Query(
+        True,
+        description="Whether to export the vectors in CSV files",
+    ),
+    export_vector_images: bool = Query(
+        False,
+        description="Whether to export images of the vectors",
+    ),
 ):
     """
     Export the specified data to a file for download.
@@ -159,6 +167,8 @@ async def export_records(
         export_images,
         export_waveform_csvs,
         export_waveform_images,
+        export_vector_csvs=export_vector_csvs,
+        export_vector_images=export_vector_images,
     )
 
     await export_handler.process_records()

--- a/operationsgateway_api/src/routes/ingest_data.py
+++ b/operationsgateway_api/src/routes/ingest_data.py
@@ -19,6 +19,7 @@ from operationsgateway_api.src.records.ingestion.partial_import_checks import (
 )
 from operationsgateway_api.src.records.ingestion.record_checks import RecordChecks
 from operationsgateway_api.src.records.record import Record
+from operationsgateway_api.src.records.vector import Vector
 from operationsgateway_api.src.records.waveform import Waveform
 
 
@@ -54,6 +55,7 @@ async def submit_hdf(
         record_data,
         waveforms,
         images,
+        vectors,
         internal_failed_channel,
     ) = await hdf_handler.extract_data()
 
@@ -67,45 +69,31 @@ async def submit_hdf(
     record_checker.optional_metadata_checks()
 
     channel_checker = ChannelChecks(
-        record_data,
-        waveforms,
-        images,
-        internal_failed_channel,
+        ingested_record=record_data,
+        ingested_waveforms=waveforms,
+        ingested_images=images,
+        ingested_vectors=vectors,
+        internal_failed_channels=internal_failed_channel,
     )
     manifest = await ChannelManifest.get_most_recent_manifest()
     channel_checker.set_channels(manifest)
     channel_dict = await channel_checker.channel_checks()
 
     if stored_record:
-        partial_import_checker = PartialImportChecks(
-            record_data,
-            stored_record,
-        )
+        partial_import_checker = PartialImportChecks(record_data, stored_record)
         accept_type = partial_import_checker.metadata_checks()
-        partial_channel_dict = partial_import_checker.channel_checks()
-
-        log.info("existent record found")
-        for key in channel_dict["rejected_channels"].keys():
-            if key in partial_channel_dict["accepted_channels"]:
-                partial_channel_dict["accepted_channels"].remove(key)
-                partial_channel_dict["rejected_channels"][key] = channel_dict[
-                    "rejected_channels"
-                ][key]
-            else:
-                partial_channel_dict["rejected_channels"][key] = channel_dict[
-                    "rejected_channels"
-                ][key]
-        checker_response = partial_channel_dict
+        checker_response = partial_import_checker.channel_checks(channel_dict)
     else:
         checker_response = channel_dict
 
     checker_response["warnings"] = list(warning) if warning else []
 
-    record_data, images, waveforms = HDFDataHandler._update_data(
+    record_data, images, waveforms, vectors = HDFDataHandler._update_data(
         checker_response,
         record_data,
         images,
         waveforms,
+        vectors=vectors,
     )
 
     record = Record(record_data)
@@ -142,9 +130,23 @@ async def submit_hdf(
         pool.close()
         image_instances = None
 
+    log.debug("Processing vectors")
+    failed_vector_uploads = []
+    for vector_model in vectors:
+        vector = Vector(vector_model)
+        failed_upload = vector.insert_vector()  # Returns channel name if failed
+        # if the upload to echo fails, don't process any further
+        if failed_upload:
+            failed_vector_uploads.append(failed_upload)
+        else:
+            vector.create_thumbnail()
+            record.store_thumbnail(vector)  # in the record not echo
+
     # Combine failed channels from waveforms and images and remove them from the record
     # Update the channel checker to reflect failed uploads
-    all_failed_upload_channels = failed_waveform_uploads + failed_image_uploads
+    all_failed_upload_channels = (
+        failed_waveform_uploads + failed_image_uploads + failed_vector_uploads
+    )
     for channel in all_failed_upload_channels:
         record.remove_channel(channel)
         if channel in checker_response["accepted_channels"]:
@@ -181,7 +183,9 @@ async def submit_hdf(
 
         # Emptying variables to save memory
         images = []
+        vectors = []
         hdf_handler.images = []
+        hdf_handler.vectors = []
         hdf_handler = None
         channel_checker = None
         waveforms = None

--- a/test/records/ingestion/test_channel.py
+++ b/test/records/ingestion/test_channel.py
@@ -1,7 +1,9 @@
 import numpy as np
+from pydantic import BaseModel
 import pytest
 
 from operationsgateway_api.src.channels.channel_manifest import ChannelManifest
+from operationsgateway_api.src.models import ScalarChannelMetadataModel
 from operationsgateway_api.src.records.ingestion.channel_checks import ChannelChecks
 from test.records.ingestion.create_test_hdf import create_test_hdf_file
 
@@ -56,20 +58,8 @@ def create_channel_response(responses, extra=None, channels=False):
 class TestChannel:
     @pytest.mark.asyncio
     async def test_channel_checks_success(self, remove_hdf_file):
-        (
-            record_data,
-            waveforms,
-            images,
-            internal_failed_channel,
-        ) = await create_test_hdf_file()
-
-        channel_checker = ChannelChecks(
-            record_data,
-            waveforms,
-            images,
-            internal_failed_channel,
-        )
-
+        hdf_tuple = await create_test_hdf_file()
+        channel_checker = ChannelChecks(*hdf_tuple)
         manifest = await ChannelManifest.get_most_recent_manifest()
         channel_checker.set_channels(manifest)
         async_functions = [
@@ -192,19 +182,8 @@ class TestChannel:
     )
     @pytest.mark.asyncio
     async def test_channel_dtype_fail(self, remove_hdf_file, altered_channel, response):
-        (
-            record_data,
-            waveforms,
-            images,
-            internal_failed_channel,
-        ) = await create_test_hdf_file(channel_dtype=altered_channel)
-
-        channel_checker = ChannelChecks(
-            record_data,
-            waveforms,
-            images,
-            internal_failed_channel,
-        )
+        hdf_tuple = await create_test_hdf_file(channel_dtype=altered_channel)
+        channel_checker = ChannelChecks(*hdf_tuple)
         manifest = await ChannelManifest.get_most_recent_manifest()
         channel_checker.set_channels(manifest)
 
@@ -367,26 +346,13 @@ class TestChannel:
         extra,
     ):
         if required_attributes == "double_waveform":
-            (
-                record_data,
-                waveforms,
-                images,
-                internal_failed_channel,
-            ) = await create_test_hdf_file(channel_name=["waveform"])
+            hdf_tuple = await create_test_hdf_file(channel_name=["waveform"])
         else:
-            (
-                record_data,
-                waveforms,
-                images,
-                internal_failed_channel,
-            ) = await create_test_hdf_file(required_attributes=required_attributes)
+            hdf_tuple = await create_test_hdf_file(
+                required_attributes=required_attributes,
+            )
 
-        channel_checker = ChannelChecks(
-            record_data,
-            waveforms,
-            images,
-            internal_failed_channel,
-        )
+        channel_checker = ChannelChecks(*hdf_tuple)
         manifest = await ChannelManifest.get_most_recent_manifest()
         channel_checker.set_channels(manifest)
 
@@ -513,19 +479,8 @@ class TestChannel:
         optional_attributes,
         response,
     ):
-        (
-            record_data,
-            waveforms,
-            images,
-            internal_failed_channel,
-        ) = await create_test_hdf_file(optional_attributes=optional_attributes)
-
-        channel_checker = ChannelChecks(
-            record_data,
-            waveforms,
-            images,
-            internal_failed_channel,
-        )
+        hdf_tuple = await create_test_hdf_file(optional_attributes=optional_attributes)
+        channel_checker = ChannelChecks(*hdf_tuple)
         manifest = await ChannelManifest.get_most_recent_manifest()
         channel_checker.set_channels(manifest)
 
@@ -661,19 +616,8 @@ class TestChannel:
         response,
         extra,
     ):
-        (
-            record_data,
-            waveforms,
-            images,
-            internal_failed_channel,
-        ) = await create_test_hdf_file(required_attributes=required_attributes)
-
-        channel_checker = ChannelChecks(
-            record_data,
-            waveforms,
-            images,
-            internal_failed_channel,
-        )
+        hdf_tuple = await create_test_hdf_file(required_attributes=required_attributes)
+        channel_checker = ChannelChecks(*hdf_tuple)
         manifest = await ChannelManifest.get_most_recent_manifest()
         channel_checker.set_channels(manifest)
 
@@ -805,19 +749,10 @@ class TestChannel:
         unrecognised_attribute,
         response,
     ):
-        (
-            record_data,
-            waveforms,
-            images,
-            internal_failed_channel,
-        ) = await create_test_hdf_file(unrecognised_attribute=unrecognised_attribute)
-
-        channel_checker = ChannelChecks(
-            record_data,
-            waveforms,
-            images,
-            internal_failed_channel,
+        hdf_tuple = await create_test_hdf_file(
+            unrecognised_attribute=unrecognised_attribute,
         )
+        channel_checker = ChannelChecks(*hdf_tuple)
         manifest = await ChannelManifest.get_most_recent_manifest()
         channel_checker.set_channels(manifest)
 
@@ -885,19 +820,8 @@ class TestChannel:
         channel_name,
         response,
     ):
-        (
-            record_data,
-            waveforms,
-            images,
-            internal_failed_channel,
-        ) = await create_test_hdf_file(channel_name=channel_name)
-
-        channel_checker = ChannelChecks(
-            record_data,
-            waveforms,
-            images,
-            internal_failed_channel,
-        )
+        hdf_tuple = await create_test_hdf_file(channel_name=channel_name)
+        channel_checker = ChannelChecks(*hdf_tuple)
         manifest = await ChannelManifest.get_most_recent_manifest()
         channel_checker.set_channels(manifest)
 
@@ -1003,12 +927,7 @@ class TestChannel:
         channels_check,
         response,
     ):
-        (
-            record_data,
-            waveforms,
-            images,
-            internal_failed_channel,
-        ) = await create_test_hdf_file(
+        hdf_tuple = await create_test_hdf_file(
             channel_dtype=channel_dtype,
             required_attributes=required_attributes,
             optional_attributes=optional_attributes,
@@ -1016,13 +935,7 @@ class TestChannel:
             channel_name=channel_name,
             channels_check=channels_check,
         )
-
-        channel_checker = ChannelChecks(
-            record_data,
-            waveforms,
-            images,
-            internal_failed_channel,
-        )
+        channel_checker = ChannelChecks(*hdf_tuple)
         manifest = await ChannelManifest.get_most_recent_manifest()
         channel_checker.set_channels(manifest)
 
@@ -1088,21 +1001,21 @@ class TestChannel:
         test_type,
         response,
     ):
-        (
-            record_data,
-            waveforms,
-            images,
-            internal_failed_channel,
-        ) = await create_test_hdf_file(test_type=test_type)
-
-        channel_checker = ChannelChecks(
-            record_data,
-            waveforms,
-            images,
-            internal_failed_channel,
-        )
+        hdf_tuple = await create_test_hdf_file(test_type=test_type)
+        channel_checker = ChannelChecks(*hdf_tuple)
         manifest = await ChannelManifest.get_most_recent_manifest()
         channel_checker.set_channels(manifest)
 
         channel_response = create_channel_response(response)
         assert await channel_checker.channel_checks() == channel_response
+
+    @pytest.mark.parametrize(
+        ["possible_model"],
+        [
+            pytest.param({}),
+            pytest.param(ScalarChannelMetadataModel(channel_dtype="scalar")),
+        ],
+    )
+    def test_ensure_dict(self, possible_model: dict | BaseModel):
+        ensured_dict = ChannelChecks._ensure_dict(possible_model)
+        assert isinstance(ensured_dict, dict)

--- a/test/records/ingestion/test_file.py
+++ b/test/records/ingestion/test_file.py
@@ -8,17 +8,15 @@ from test.records.ingestion.create_test_hdf import create_test_hdf_file
 class TestFile:
     @pytest.mark.asyncio
     async def test_file_checks_pass(self, remove_hdf_file):
-        record_data, _, _, _ = await create_test_hdf_file()
-        file_checker = FileChecks(record_data)
+        hdf_tuple = await create_test_hdf_file()
+        file_checker = FileChecks(hdf_tuple[0])
 
         file_checker.epac_data_version_checks()
 
     @pytest.mark.asyncio
     async def test_minor_version_too_high(self, remove_hdf_file):
-        record_data, _, _, _ = await create_test_hdf_file(
-            data_version=["1.4", "exists"],
-        )
-        file_checker = FileChecks(record_data)
+        hdf_tuple = await create_test_hdf_file(data_version=["1.4", "exists"])
+        file_checker = FileChecks(hdf_tuple[0])
 
         assert (
             file_checker.epac_data_version_checks()
@@ -52,8 +50,8 @@ class TestFile:
         match,
         remove_hdf_file,
     ):
-        record_data, _, _, _ = await create_test_hdf_file(data_version=data_version)
-        file_checker = FileChecks(record_data)
+        hdf_tuple = await create_test_hdf_file(data_version=data_version)
+        file_checker = FileChecks(hdf_tuple[0])
 
         with pytest.raises(RejectFileError, match=match):
             file_checker.epac_data_version_checks()

--- a/test/records/ingestion/test_partial_import.py
+++ b/test/records/ingestion/test_partial_import.py
@@ -44,9 +44,9 @@ class TestPartialImport:
     @pytest.mark.asyncio
     async def test_metadata_checks(self, remove_hdf_file, test_type, response):
 
-        record_data, _, _, _ = await create_test_hdf_file()
+        hdf_tuple = await create_test_hdf_file()
 
-        stored_record = copy.deepcopy(record_data)
+        stored_record = copy.deepcopy(hdf_tuple[0])
 
         if test_type == "time":
             # alter so only time matches
@@ -68,10 +68,7 @@ class TestPartialImport:
             # alter so only shotnum is wrong
             stored_record.metadata.shotnum = 234
 
-        partial_import_checker = PartialImportChecks(
-            record_data,
-            stored_record,
-        )
+        partial_import_checker = PartialImportChecks(hdf_tuple[0], stored_record)
 
         if test_type == "match" or test_type == "neither":
             assert partial_import_checker.metadata_checks() == response
@@ -187,8 +184,8 @@ class TestPartialImport:
     @pytest.mark.asyncio
     async def test_import_channel_checks(self, remove_hdf_file, test_type, response):
 
-        record_data, _, _, _ = await create_test_hdf_file()
-        stored_record = copy.deepcopy(record_data)
+        hdf_tuple = await create_test_hdf_file()
+        stored_record = copy.deepcopy(hdf_tuple[0])
 
         if test_type == "some":
             channels = stored_record.channels
@@ -215,21 +212,17 @@ class TestPartialImport:
             channels["n"] = channels.pop("PM-201-TJ-CAM-2-CENY")
             channels["o"] = channels.pop("PM-201-TJ-CAM-2-FWHMY")
 
-        partial_import_checker = PartialImportChecks(
-            record_data,
-            stored_record,
-        )
+        partial_import_checker = PartialImportChecks(hdf_tuple[0], stored_record)
 
         # This test doesn't use any data stored in the database/Echo, it provides
         # instances of RecordModel as inputs to PartialImportChecks. For image and
         # waveform channels, a check is conducted to make sure the associated
         # image/waveform is actually on Echo and because we're not using stored data for
         # this test, we need to mock that check
-        with patch.object(
-            partial_import_checker,
-            "_is_image_or_waveform_stored",
-        ) as mock_is_stored:
+        with patch.object(partial_import_checker.echo, "head_object") as mock_is_stored:
             mock_is_stored.return_value = True
-            partial_import_channel_checks = partial_import_checker.channel_checks()
+            partial_import_channel_checks = partial_import_checker.channel_checks(
+                {"rejected_channels": {}},
+            )
 
         assert partial_import_channel_checks == response

--- a/test/records/ingestion/test_record_checks.py
+++ b/test/records/ingestion/test_record_checks.py
@@ -36,11 +36,11 @@ class TestRecordChecks:
         active_experiment,
         remove_hdf_file,
     ):
-        record_data, _, _, _ = await create_test_hdf_file(
+        hdf_tuple = await create_test_hdf_file(
             shotnum=shotnum,
             active_experiment=active_experiment,
         )
-        record_checker = RecordChecks(record_data)
+        record_checker = RecordChecks(hdf_tuple[0])
 
         record_checker.active_area_checks()
         record_checker.optional_metadata_checks()
@@ -102,18 +102,18 @@ class TestRecordChecks:
     ):
         if test == "other":
             with pytest.raises(ModelError):
-                record_data, _, _, _ = await create_test_hdf_file(
+                hdf_tuple = await create_test_hdf_file(
                     active_area=active_area,
                     shotnum=shotnum,
                     active_experiment=active_experiment,
                 )
         else:
-            record_data, _, _, _ = await create_test_hdf_file(
+            hdf_tuple = await create_test_hdf_file(
                 active_area=active_area,
                 shotnum=shotnum,
                 active_experiment=active_experiment,
             )
-            record_checker = RecordChecks(record_data)
+            record_checker = RecordChecks(hdf_tuple[0])
 
             with pytest.raises(RejectRecordError, match=match):
                 if test == "timestamp":


### PR DESCRIPTION
## Changes
- **Add vector thumbnail size to config**
- **Add error for when Vectors can't be retrieved**
- **Added Pydantic models for Vectors**
- **Added export support for vectors**
- **Added ingestion and channel check support for vectors**
- **Added functions to insert, get, and generate .pngs from Vectors (as a bar chart)**

Other changes are shared with those proposed in https://github.com/ral-facilities/operationsgateway-api/pull/160 (head_object, refactors, etc.)

Not yet implemented support for functions + vectors. This may be a requirement to allow users to limit which bars they want to see. Will do that as a separate PR to keep lines changed down.

## Tests
As with https://github.com/ral-facilities/operationsgateway-api/pull/160, until the data sim is updated to produce vector data, our testing model makes it impossible to get coverage without appropriate channels.