### PR TITLE
Relax auth on GET maintenance endpoints, rename to /scheduled_maintenance

### DIFF
--- a/operationsgateway_api/src/routes/maintenance.py
+++ b/operationsgateway_api/src/routes/maintenance.py
@@ -21,7 +21,7 @@ AuthoriseRoute = Annotated[str, Depends(authorise_route)]
     response_description="The current maintenance message and whether to show it",
     tags=["Maintenance"],
 )
-def get_maintenance(access_token: AuthoriseRoute) -> MaintenanceModel:
+def get_maintenance() -> MaintenanceModel:
     return _get_maintenance()
 
 
@@ -40,21 +40,19 @@ def set_maintenance(
 
 
 @router.get(
-    "/maintenance/scheduled",
+    "/scheduled_maintenance",
     summary="Get the current scheduled maintenance message and whether to show it",
     response_description=(
         "The current scheduled maintenance message and whether to show it"
     ),
     tags=["Maintenance"],
 )
-def get_scheduled_maintenance(
-    access_token: AuthoriseRoute,
-) -> ScheduledMaintenanceModel:
+def get_scheduled_maintenance() -> ScheduledMaintenanceModel:
     return _get_scheduled_maintenance()
 
 
 @router.post(
-    "/maintenance/scheduled",
+    "/scheduled_maintenance",
     summary="Set the current scheduled maintenance message and whether to show it",
     tags=["Maintenance"],
 )

--- a/operationsgateway_api/src/users/user.py
+++ b/operationsgateway_api/src/users/user.py
@@ -20,10 +20,8 @@ class User:
         "/users PATCH",
         "/users GET",
         "/users/{id_} DELETE",
-        "/maintenance GET"
-        "/maintenance POST"
-        "/maintenance/scheduled GET"
-        "/maintenance/scheduled POST",
+        "/maintenance POST",
+        "/scheduled_maintenance POST",
     ]
 
     auth_type_list = [

--- a/test/endpoints/test_get_users.py
+++ b/test/endpoints/test_get_users.py
@@ -28,10 +28,8 @@ class TestGetUsers:
                     "/users PATCH",
                     "/users/{id_} DELETE",
                     "/users GET",
-                    "/maintenance GET",
                     "/maintenance POST",
-                    "/maintenance/scheduled GET",
-                    "/maintenance/scheduled POST",
+                    "/scheduled_maintenance POST",
                 ],
             },
         ]

--- a/util/og_api_postman_collection.json
+++ b/util/og_api_postman_collection.json
@@ -2061,14 +2061,7 @@
 					"name": "Get Maintenance",
 					"request": {
 						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{og-access-token}}",
-									"type": "string"
-								}
-							]
+							"type": "noauth"
 						},
 						"method": "GET",
 						"header": [],
@@ -2121,28 +2114,49 @@
 					"response": []
 				},
 				{
-					"name": "Get Scheduled Maintenance",
+					"name": "Set Maintenance failure",
 					"request": {
 						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{og-access-token}}",
-									"type": "string"
-								}
-							]
+							"type": "noauth"
 						},
-						"method": "GET",
+						"method": "POST",
 						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"show\": true,\r\n    \"message\": \"message\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
 						"url": {
-							"raw": "{{og-api}}/maintenance/scheduled",
+							"raw": "{{og-api}}/maintenance",
 							"host": [
 								"{{og-api}}"
 							],
 							"path": [
-								"maintenance",
-								"scheduled"
+								"maintenance"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Scheduled Maintenance",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{og-api}}/scheduled_maintenance",
+							"host": [
+								"{{og-api}}"
+							],
+							"path": [
+								"scheduled_maintenance"
 							]
 						}
 					},
@@ -2173,13 +2187,41 @@
 							}
 						},
 						"url": {
-							"raw": "{{og-api}}/maintenance/scheduled",
+							"raw": "{{og-api}}/scheduled_maintenance",
 							"host": [
 								"{{og-api}}"
 							],
 							"path": [
-								"maintenance",
-								"scheduled"
+								"scheduled_maintenance"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Set Scheduled Maintenance failure",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"show\": true,\r\n    \"message\": \"message\",\r\n    \"severity\": \"warning\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{og-api}}/scheduled_maintenance",
+							"host": [
+								"{{og-api}}"
+							],
+							"path": [
+								"scheduled_maintenance"
 							]
 						}
 					},

--- a/util/users_for_mongoimport.json
+++ b/util/users_for_mongoimport.json
@@ -2,7 +2,7 @@
 { "_id" : "xfu59478", "auth_type" : "FedID" }
 { "_id" : "dgs12138", "auth_type" : "FedID" }
 { "_id" : "frontend", "auth_type" : "local", "sha256_password" : "2d8d693177ac44895fc02c009ec3f6af32e51eb00783c17000d7051d1662b93a" }
-{ "_id" : "backend", "auth_type" : "local", "sha256_password" : "3c482346f375027677fa8a0d6830a32714d4f13f9e94c2d9e215e0ac205ad4e5", "authorised_routes" : [ "/submit/hdf POST", "/submit/manifest POST", "/records/{id_} DELETE", "/experiments POST", "/users POST", "/users GET", "/users PATCH", "/users/{id_} DELETE", "/maintenance GET", "/maintenance POST", "/maintenance/scheduled GET", "/maintenance/scheduled POST" ] }
+{ "_id" : "backend", "auth_type" : "local", "sha256_password" : "3c482346f375027677fa8a0d6830a32714d4f13f9e94c2d9e215e0ac205ad4e5", "authorised_routes" : [ "/submit/hdf POST", "/submit/manifest POST", "/records/{id_} DELETE", "/experiments POST", "/users POST", "/users GET", "/users PATCH", "/users/{id_} DELETE", "/maintenance POST", "/scheduled_maintenance POST" ] }
 { "_id" : "hdf_import", "auth_type" : "local", "sha256_password" : "d942f64886578d8747312e368ed92d9f6b2a8d45556f0f924e2444fe911d15af", "authorised_routes" : [ "/submit/hdf POST", "/submit/manifest POST" ] }
 { "_id" : "no_auth_type_user" }
 { "_id" : "invalid_auth_type_user", "auth_type" : "Invalid" }


### PR DESCRIPTION
## Changes 
- Remove auth requirements on GET endpoints
- Rename `/maintenance/scheduled` to `/scheduled_maintenance`
- Fix unintentionally concatenated string in `authorised_route_list` (as suspected Python will interpret the "missing" commas as a single multiline string):
```python
>>> authorised_route_list = [
...         "/submit/hdf POST",
...         "/submit/manifest POST",
...         "/records/{id_} DELETE",
...         "/experiments POST",
...         "/users POST",
...         "/users PATCH",
...         "/users GET",
...         "/users/{id_} DELETE",
...         "/maintenance GET"
...         "/maintenance POST"
...         "/scheduled_maintenance GET"
...         "/scheduled_maintenance POST",
...     ]
>>> authorised_route_list
['/submit/hdf POST', '/submit/manifest POST', '/records/{id_} DELETE', '/experiments POST', '/users POST', '/users PATCH', '/users GET', '/users/{id_} DELETE', '/maintenance GET/maintenance POST/scheduled_maintenance GET/scheduled_maintenance POST']
```

## Tests
- Update test to not send token for GETs - verifying client requests from unlogged in users will pass
- Add tests that low permission user `frontend` cannot POST

## Postman
- Removed auth from GETs
- Added failing POST requests