### PR TITLE
Update delete_by_record_id to use subdirectories

### DIFF
--- a/operationsgateway_api/src/routes/records.py
+++ b/operationsgateway_api/src/routes/records.py
@@ -274,9 +274,17 @@ async def delete_record_by_id(
 
     await Record.delete_record(id_)
     echo = EchoInterface()
+    # In principle historic data might be in the old directory format on Echo, so delete
+    # in both locations
+    sub_directories = EchoInterface.format_record_id(record_id=id_)
+    directory = EchoInterface.format_record_id(record_id=id_, use_subdirectories=False)
+
     log.info("Deleting waveforms for record ID '%s'", id_)
-    echo.delete_directory(f"{Waveform.echo_prefix}/{id_}/")
+    echo.delete_directory(f"{Waveform.echo_prefix}/{sub_directories}/")
+    echo.delete_directory(f"{Waveform.echo_prefix}/{directory}/")
+
     log.info("Deleting images for record ID '%s'", id_)
-    echo.delete_directory(f"{Image.echo_prefix}/{id_}/")
+    echo.delete_directory(f"{Image.echo_prefix}/{sub_directories}/")
+    echo.delete_directory(f"{Image.echo_prefix}/{directory}/")
 
     return Response(status_code=HTTPStatus.NO_CONTENT.value)

--- a/test/endpoints/test_delete_record.py
+++ b/test/endpoints/test_delete_record.py
@@ -38,3 +38,35 @@ class TestDeleteRecordById:
             Prefix=f"{Image.echo_prefix}/{record_id}/",
         )
         assert list(image_query) == []
+
+    @pytest.mark.asyncio
+    async def test_delete_record_subdirectories_success(
+        self,
+        test_app: TestClient,
+        login_and_get_token,
+        data_for_delete_records_subdirectories: str,
+    ):
+        delete_response = test_app.delete(
+            f"/records/{data_for_delete_records_subdirectories}",
+            headers={"Authorization": f"Bearer {login_and_get_token}"},
+        )
+
+        assert delete_response.status_code == 204
+        # Checks the record has been deleted from the database
+        with pytest.raises(MissingDocumentError):
+            await Record.find_record_by_id(data_for_delete_records_subdirectories, {})
+
+        # Check that waveform and image have been removed from Echo
+        echo = EchoInterface()
+        subdirectories = EchoInterface.format_record_id(
+            data_for_delete_records_subdirectories,
+        )
+        waveform_query = echo.bucket.objects.filter(
+            Prefix=f"{Waveform.echo_prefix}/{subdirectories}/",
+        )
+        assert list(waveform_query) == []
+
+        image_query = echo.bucket.objects.filter(
+            Prefix=f"{Image.echo_prefix}/{subdirectories}/",
+        )
+        assert list(image_query) == []


### PR DESCRIPTION
While discussing the deletion of old records in the sprint, I noticed that the `delete_record_by_id` endpoint was using the record_id directly in the Echo path. This is fine for the historical data, but since the new data goes in subdirectories by default we should try and purge both locations.