### PR TITLE
Adding healthcheck user

### DIFF
--- a/operationsgateway_api/config.yml.example
+++ b/operationsgateway_api/config.yml.example
@@ -9,7 +9,7 @@ app:
   maintenance_file: operationsgateway_api/maintenance.json.example
   scheduled_maintenance_file: operationsgateway_api/scheduled_maintenance.json.example
 healthcheck:
-# Defines the username & password needed for a script that checks the api is working
+  # Defines the username & password needed for a script that checks the api is working
   username: username
   password: password
 images:

--- a/operationsgateway_api/config.yml.example
+++ b/operationsgateway_api/config.yml.example
@@ -8,6 +8,10 @@ app:
   url_prefix: ""
   maintenance_file: operationsgateway_api/maintenance.json.example
   scheduled_maintenance_file: operationsgateway_api/scheduled_maintenance.json.example
+healthcheck:
+# Defines the username & password needed for a script that checks the api is working
+  username: username
+  password: password
 images:
   # Thumbnail sizes should only ever be two element lists, of a x, y resolution
   thumbnail_size: [50, 50]

--- a/util/users_for_mongoimport.json
+++ b/util/users_for_mongoimport.json
@@ -1,6 +1,7 @@
 { "_id" : "rqw38472", "auth_type" : "FedID" }
 { "_id" : "xfu59478", "auth_type" : "FedID" }
 { "_id" : "dgs12138", "auth_type" : "FedID" }
+{ "_id" : "healthcheck", "auth_type" : "local", "sha256_password" : "62484e22a6a5ade1ba25cb1b7c55c4b8861de24caddab73c9409742734008b26", "authorised_routes" : [ "/images/{id_} GET", "/records/{id_} GET" ] }
 { "_id" : "frontend", "auth_type" : "local", "sha256_password" : "2d8d693177ac44895fc02c009ec3f6af32e51eb00783c17000d7051d1662b93a" }
 { "_id" : "backend", "auth_type" : "local", "sha256_password" : "3c482346f375027677fa8a0d6830a32714d4f13f9e94c2d9e215e0ac205ad4e5", "authorised_routes" : [ "/submit/hdf POST", "/submit/manifest POST", "/records/{id_} DELETE", "/experiments POST", "/users POST", "/users GET", "/users PATCH", "/users/{id_} DELETE", "/maintenance POST", "/scheduled_maintenance POST" ] }
 { "_id" : "hdf_import", "auth_type" : "local", "sha256_password" : "d942f64886578d8747312e368ed92d9f6b2a8d45556f0f924e2444fe911d15af", "authorised_routes" : [ "/submit/hdf POST", "/submit/manifest POST" ] }

--- a/util/users_for_mongoimport.json
+++ b/util/users_for_mongoimport.json
@@ -1,7 +1,7 @@
 { "_id" : "rqw38472", "auth_type" : "FedID" }
 { "_id" : "xfu59478", "auth_type" : "FedID" }
 { "_id" : "dgs12138", "auth_type" : "FedID" }
-{ "_id" : "healthcheck", "auth_type" : "local", "sha256_password" : "62484e22a6a5ade1ba25cb1b7c55c4b8861de24caddab73c9409742734008b26", "authorised_routes" : [ "/images/{id_} GET", "/records/{id_} GET" ] }
+{ "_id" : "healthcheck", "auth_type" : "local", "sha256_password" : "62484e22a6a5ade1ba25cb1b7c55c4b8861de24caddab73c9409742734008b26", "authorised_routes" : [ "/images/{id_} GET", "/records/{id_} GET", "/submit/hdf POST", "/records/{id_} DELETE" ] }
 { "_id" : "frontend", "auth_type" : "local", "sha256_password" : "2d8d693177ac44895fc02c009ec3f6af32e51eb00783c17000d7051d1662b93a" }
 { "_id" : "backend", "auth_type" : "local", "sha256_password" : "3c482346f375027677fa8a0d6830a32714d4f13f9e94c2d9e215e0ac205ad4e5", "authorised_routes" : [ "/submit/hdf POST", "/submit/manifest POST", "/records/{id_} DELETE", "/experiments POST", "/users POST", "/users GET", "/users PATCH", "/users/{id_} DELETE", "/maintenance POST", "/scheduled_maintenance POST" ] }
 { "_id" : "hdf_import", "auth_type" : "local", "sha256_password" : "d942f64886578d8747312e368ed92d9f6b2a8d45556f0f924e2444fe911d15af", "authorised_routes" : [ "/submit/hdf POST", "/submit/manifest POST" ] }


### PR DESCRIPTION
To check that the API is working, a script needs to be written that makes the appropriate calls and outputs the result in a format Icinga can understand. 

The API "working" is defined as being able to `/GET`, `/PUT`, `/DELETE` data from Mongo and echo. This will likely be expanded in the future to accommodate the checking of the `background_scheduler` cron job.

The python script itself will be deployed on the rig machine using the Ansible script. 

The ansible script manages credentials by storing them in a vault and then replacing the necessary auth item in the [config](https://github.com/ral-facilities/operationsgateway-ansible/blob/main/roles/operationsgateway-api/templates/config.yml.j2).
In order to keep all credentials in the same place, this PR:
-  creates the necessary user in the config file,  for the healthcheck script to grab from the file
-  creates the necessary test user with appropriate route permissions

This PR has a matching one in the ansible repo [here](https://github.com/ral-facilities/operationsgateway-ansible/pull/28).

I haven't included any automated tests as I'd class this as a deployment thing rather than a functional API change, but let me know if you feel strongly about it either way.