### PR TITLE
Dsegog 410 warning for file version number too high received as a char array instead of a string

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 # .flake8
 [flake8]
 select = A,B,B9,BLK,C,E,F,I,N,S,W
-ignore = E203,W503,E501,B905
+ignore = E203,W503,E501,B905,C901
 max-complexity = 12
 max-line-length = 80
 application-import-names = operationsgateway_api,test

--- a/operationsgateway_api/src/routes/ingest_data.py
+++ b/operationsgateway_api/src/routes/ingest_data.py
@@ -49,6 +49,7 @@ async def submit_hdf(
     log.info("Submitting CLF data in HDF file to be processed then stored in MongoDB")
     log.debug("Filename: %s, Content: %s", file.filename, file.content_type)
 
+    warnings = []
     hdf_handler = HDFDataHandler(file.file)
     (
         record_data,
@@ -62,6 +63,9 @@ async def submit_hdf(
 
     file_checker = FileChecks(record_data)
     warning = file_checker.epac_data_version_checks()
+    if warning:
+        warnings.append(warning)
+
     record_checker = RecordChecks(record_data)
     record_checker.active_area_checks()
     record_checker.optional_metadata_checks()
@@ -99,7 +103,7 @@ async def submit_hdf(
     else:
         checker_response = channel_dict
 
-    checker_response["warnings"] = list(warning) if warning else []
+    checker_response["warnings"] = warnings
 
     record_data, images, waveforms = HDFDataHandler._update_data(
         checker_response,


### PR DESCRIPTION
The warnings were being displayed as a list of chars instead of a list of strings.

Now the ingest endpoint returns, for example:

`"warnings": [
            "File minor version number too high (expected <=1)"
        ]`

I've had to suppress the linter for now and have [created an item in the backlog](https://stfc.atlassian.net/browse/DSEGOG-415) to deal with this later.