### PR TITLE
Dsegog 411 problems with timestamp give unknown error instead of useful details

### DIFF
--- a/operationsgateway_api/src/constants.py
+++ b/operationsgateway_api/src/constants.py
@@ -5,5 +5,5 @@ from pathlib import Path
 # <function get_full_image at 0x7f171d7039d0>, '/images/{record_id}/{channel_name} GET'
 ROUTE_MAPPINGS = {}
 ID_DATETIME_FORMAT = "%Y%m%d%H%M%S"
-DATA_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+DATA_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 LOG_CONFIG_LOCATION = str(Path(__file__).parent.parent / "logging.ini")

--- a/operationsgateway_api/src/records/ingestion/hdf_handler.py
+++ b/operationsgateway_api/src/records/ingestion/hdf_handler.py
@@ -7,7 +7,7 @@ import h5py
 from pydantic import ValidationError
 
 from operationsgateway_api.src.channels.channel_manifest import ChannelManifest
-from operationsgateway_api.src.constants import DATA_DATETIME_FORMAT, ID_DATETIME_FORMAT
+from operationsgateway_api.src.constants import ID_DATETIME_FORMAT
 from operationsgateway_api.src.exceptions import HDFDataExtractionError, ModelError
 from operationsgateway_api.src.models import (
     ChannelManifestModel,
@@ -78,13 +78,13 @@ class HDFDataHandler:
 
         metadata_hdf = dict(self.hdf_file.attrs)
         try:
-            metadata_hdf["timestamp"] = datetime.strptime(
+            metadata_hdf["timestamp"] = datetime.fromisoformat(
                 metadata_hdf["timestamp"],
-                DATA_DATETIME_FORMAT,
             )
-        except (KeyError, ValueError) as exc:
+        except (KeyError, ValueError, TypeError) as exc:
             raise HDFDataExtractionError(
-                f"Invalid timestamp metadata. Expected key 'timestamp' with value formatted as '{DATA_DATETIME_FORMAT}'."
+                "Invalid timestamp metadata. Expected key 'timestamp' with value "
+                "formatted as ISO 8601 (e.g., 'YYYY-MM-DDTHH:MM:SS±HH:MM').",
             ) from exc
 
         self.record_id = metadata_hdf["timestamp"].strftime(ID_DATETIME_FORMAT)

--- a/operationsgateway_api/src/records/ingestion/hdf_handler.py
+++ b/operationsgateway_api/src/records/ingestion/hdf_handler.py
@@ -77,28 +77,15 @@ class HDFDataHandler:
         log.debug("Extracting data from HDF files")
 
         metadata_hdf = dict(self.hdf_file.attrs)
-        timestamp_format = "%Y-%m-%dT%H:%M:%S%z"
         try:
             metadata_hdf["timestamp"] = datetime.strptime(
                 metadata_hdf["timestamp"],
-                timestamp_format,
+                DATA_DATETIME_FORMAT,
             )
-        except ValueError:
-            # Try using alternative timestamp format that might be used for older HDF
-            # files such as old Gemini test data
-            # TODO - when Gemini test data is no longer needed, remove this try/except
-            # block that attempts to convert the timestamp for a second time. Go
-            # straight to raising the exception instead
-            try:
-                metadata_hdf["timestamp"] = datetime.strptime(
-                    metadata_hdf["timestamp"],
-                    DATA_DATETIME_FORMAT,
-                )
-            except ValueError as exc:
-                raise HDFDataExtractionError(
-                    "Incorrect timestamp format for metadata timestamp. Use"
-                    f" {timestamp_format} instead",
-                ) from exc
+        except (KeyError, ValueError) as exc:
+            raise HDFDataExtractionError(
+                f"Invalid timestamp metadata. Expected key 'timestamp' with value formatted as '{DATA_DATETIME_FORMAT}'."
+            ) from exc
 
         self.record_id = metadata_hdf["timestamp"].strftime(ID_DATETIME_FORMAT)
         await self.extract_channels()

--- a/operationsgateway_api/src/records/ingestion/hdf_handler.py
+++ b/operationsgateway_api/src/records/ingestion/hdf_handler.py
@@ -7,7 +7,7 @@ import h5py
 from pydantic import ValidationError
 
 from operationsgateway_api.src.channels.channel_manifest import ChannelManifest
-from operationsgateway_api.src.constants import ID_DATETIME_FORMAT
+from operationsgateway_api.src.constants import DATA_DATETIME_FORMAT, ID_DATETIME_FORMAT
 from operationsgateway_api.src.exceptions import HDFDataExtractionError, ModelError
 from operationsgateway_api.src.models import (
     ChannelManifestModel,
@@ -78,13 +78,14 @@ class HDFDataHandler:
 
         metadata_hdf = dict(self.hdf_file.attrs)
         try:
-            metadata_hdf["timestamp"] = datetime.fromisoformat(
+            metadata_hdf["timestamp"] = datetime.strptime(
                 metadata_hdf["timestamp"],
+                DATA_DATETIME_FORMAT,
             )
         except (KeyError, ValueError, TypeError) as exc:
             raise HDFDataExtractionError(
                 "Invalid timestamp metadata. Expected key 'timestamp' with value "
-                "formatted as ISO 8601 (e.g., 'YYYY-MM-DDTHH:MM:SS±HH:MM').",
+                "formatted, for example as: '2025-04-07T14:28:16+00:00'.",
             ) from exc
 
         self.record_id = metadata_hdf["timestamp"].strftime(ID_DATETIME_FORMAT)

--- a/operationsgateway_api/src/records/ingestion/partial_import_checks.py
+++ b/operationsgateway_api/src/records/ingestion/partial_import_checks.py
@@ -43,7 +43,7 @@ class PartialImportChecks:
         try:
             time_match = (ingested_metadata.timestamp).replace(
                 tzinfo=None,
-            ) == stored_metadata.timestamp
+            ) == stored_metadata.timestamp.replace(tzinfo=None)
         except Exception:
             time_match = (ingested_metadata.timestamp) == stored_metadata.timestamp
 

--- a/test/endpoints/test_submit_hdf.py
+++ b/test/endpoints/test_submit_hdf.py
@@ -23,7 +23,7 @@ def create_integration_test_hdf(fails=None, generic_fail=None):
     with h5py.File("test.h5", "w") as f:
         f.attrs.create("epac_ops_data_version", "1.0")
         record = f["/"]
-        record.attrs.create("timestamp", "2020-04-07T14:28:16+0000")
+        record.attrs.create("timestamp", "2020-04-07T14:28:16+00:00")
         record.attrs.create("shotnum", 366272, dtype="u8")
         record.attrs.create("active_area", "ea1")
         record.attrs.create("active_experiment", "90097341")

--- a/test/endpoints/test_submit_hdf.py
+++ b/test/endpoints/test_submit_hdf.py
@@ -23,7 +23,7 @@ def create_integration_test_hdf(fails=None, generic_fail=None):
     with h5py.File("test.h5", "w") as f:
         f.attrs.create("epac_ops_data_version", "1.0")
         record = f["/"]
-        record.attrs.create("timestamp", "2020-04-07 14:28:16")
+        record.attrs.create("timestamp", "2020-04-07T14:28:16+0000")
         record.attrs.create("shotnum", 366272, dtype="u8")
         record.attrs.create("active_area", "ea1")
         record.attrs.create("active_experiment", "90097341")

--- a/test/records/ingestion/create_test_hdf.py
+++ b/test/records/ingestion/create_test_hdf.py
@@ -86,7 +86,7 @@ async def create_test_hdf_file(  # noqa: C901
 
     data_version = data_version if data_version is not None else ["1.0", "exists"]
     timestamp = (
-        timestamp if timestamp is not None else ["2020-04-07 14:28:16", "exists"]
+        timestamp if timestamp is not None else ["2020-04-07T14:28:16+0000", "exists"]
     )
     active_area = active_area if active_area is not None else ["ea1", "exists"]
     shotnum = shotnum if shotnum is not None else ["valid", "exists"]

--- a/test/records/ingestion/create_test_hdf.py
+++ b/test/records/ingestion/create_test_hdf.py
@@ -86,7 +86,7 @@ async def create_test_hdf_file(  # noqa: C901
 
     data_version = data_version if data_version is not None else ["1.0", "exists"]
     timestamp = (
-        timestamp if timestamp is not None else ["2020-04-07T14:28:16+0000", "exists"]
+        timestamp if timestamp is not None else ["2020-04-07T14:28:16+00:00", "exists"]
     )
     active_area = active_area if active_area is not None else ["ea1", "exists"]
     shotnum = shotnum if shotnum is not None else ["valid", "exists"]

--- a/test/records/ingestion/test_hdf_handler.py
+++ b/test/records/ingestion/test_hdf_handler.py
@@ -14,7 +14,7 @@ def create_test_hdf_file(timestamp_test=False, data_test=False):
         if timestamp_test:
             record.attrs.create("timestamp", "20t0-04 07 a4 mh 228:1")
         else:
-            record.attrs.create("timestamp", "2020-04-07 14:28:16")
+            record.attrs.create("timestamp", "2020-04-07T14:28:16+0000")
         record.attrs.create("shotnum", 366272, dtype="u8")
         record.attrs.create("active_area", "ea1")
         record.attrs.create("active_experiment", "90097341")
@@ -55,6 +55,6 @@ class TestHDFDataHandler:
         instance = HDFDataHandler("test.h5")
         with pytest.raises(
             HDFDataExtractionError,
-            match="Incorrect timestamp format for metadata timestamp. Use",
+            match="Invalid timestamp metadata",
         ):
             await instance.extract_data()

--- a/test/records/ingestion/test_partial_import.py
+++ b/test/records/ingestion/test_partial_import.py
@@ -60,12 +60,12 @@ class TestPartialImport:
         elif test_type == "num":
             # alter so only num matches
             stored_record.metadata.epac_ops_data_version = "2.3"
-            stored_record.metadata.timestamp = "3122-04-07T14:28:16+0000"
+            stored_record.metadata.timestamp = "3122-04-07T14:28:16+00:00"
             stored_record.metadata.active_area = "ae2"
             stored_record.metadata.active_experiment = "4898"
         elif test_type == "neither":
             # alter so neither shotnum nor timestamp matches
-            stored_record.metadata.timestamp = "3122-04-07T14:28:16+0000"
+            stored_record.metadata.timestamp = "3122-04-07T14:28:16+00:00"
             stored_record.metadata.shotnum = 234
         elif test_type == "single":
             # alter so only shotnum is wrong

--- a/test/records/ingestion/test_partial_import.py
+++ b/test/records/ingestion/test_partial_import.py
@@ -60,12 +60,12 @@ class TestPartialImport:
         elif test_type == "num":
             # alter so only num matches
             stored_record.metadata.epac_ops_data_version = "2.3"
-            stored_record.metadata.timestamp = "3122-04-07 14:28:16"
+            stored_record.metadata.timestamp = "3122-04-07T14:28:16+0000"
             stored_record.metadata.active_area = "ae2"
             stored_record.metadata.active_experiment = "4898"
         elif test_type == "neither":
             # alter so neither shotnum nor timestamp matches
-            stored_record.metadata.timestamp = "3122-04-07 14:28:16"
+            stored_record.metadata.timestamp = "3122-04-07T14:28:16+0000"
             stored_record.metadata.shotnum = 234
         elif test_type == "single":
             # alter so only shotnum is wrong


### PR DESCRIPTION
While looking at the timestamp issue, which responded with a 500 if the `timestamp` key was incorrect, I found some code that suggested it should be deleted if Gemini data was no longer being used. 

Gemini data used a timestamp in the format: "%Y-%m-%d %H:%M:%S" (e.g: 2020-04-07 14:28:16) whereas the [EPAC data sim](https://github.com/CentralLaserFacility/EPAC-DataSim/blob/47fe5de1b89d81aaf6943e7c58b0c3fedae1a04f/src/epac_data_sim/writer.py#L21) produces timestamps which are ISO8601 compliant, which matches the Interface Exchange Spec ([page 2](https://stfc365.sharepoint.com/:w:/r/sites/CLFDataDiscoveryAndExperimentalDataManagement/_layouts/15/Doc.aspx?sourcedoc=%7B27352519-B7BC-4CCC-96D9-45A37BFBF5E9%7D&file=OpsGateway%20data%20interchange%20format.docx)) .

However, I was looking at [`datetime.fromisoformat`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat) to do the checks, but it's surprisingly lenient for Python 3.11. For example, out of the box: `'2011-11-04'` is deemed a valid ISO 8601 datetime. Given this, I've stuck to the existing const: `DATA_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S%z"` as that's been used for a while now.

This PR:
- Addresses the incorrect timestamp key issue
- Removes the old Gemini timestamp format as it is no longer used
- Add some tests to test an array of timestamps
- Changes existing tests to have a time zone