### PR TITLE
Add wavefront channel types to /channels/summary

### DIFF
--- a/operationsgateway_api/src/records/record.py
+++ b/operationsgateway_api/src/records/record.py
@@ -223,13 +223,15 @@ class Record:
     async def get_recent_channel_values(
         channel_name: str,
         colourmap_name: str,
+        float_colourmap: str,
     ) -> List[Union[str, int, float]]:
         """
         Return the most recent three values for a particular channel
 
         Depending on the channel type, different samples will be collected:
         - Scalar: return the values themselves
-        - Image or waveform: return the thumbnails of the data they represent
+        - Image, float image, waveform or vector: return the thumbnails of the data they
+          represent
         """
 
         channel_path = f"channels.{channel_name}"
@@ -248,9 +250,10 @@ class Record:
         recent_values = []
         for record in records:
             channel = record.channels[channel_name]
+            data = None
 
             if channel.metadata.channel_dtype == "scalar":
-                recent_values.append({record.metadata.timestamp: channel.data})
+                data = channel.data
             elif channel.metadata.channel_dtype == "image":
                 thumbnail_bytes = FalseColourHandler.apply_false_colour_to_b64_img(
                     channel.thumbnail,
@@ -258,16 +261,23 @@ class Record:
                     None,
                     colourmap_name,
                 )
-                thumbnail_bytes.seek(0)
-                recent_values.append(
-                    {
-                        record.metadata.timestamp: base64.b64encode(
-                            thumbnail_bytes.getvalue(),
-                        ),
-                    },
-                )
+                data = base64.b64encode(thumbnail_bytes.getvalue())
             elif channel.metadata.channel_dtype == "waveform":
-                recent_values.append({record.metadata.timestamp: channel.thumbnail})
+                data = channel.thumbnail
+            elif channel.metadata.channel_dtype == ChannelDtype.VECTOR:
+                data = channel.thumbnail
+            elif channel.metadata.channel_dtype == ChannelDtype.FLOAT_IMAGE:
+                bytes_io = FalseColourHandler.apply_false_colour_to_b64_float_img(
+                    channel.thumbnail,
+                    float_colourmap,
+                )
+                data = base64.b64encode(bytes_io.getvalue())
+            else:
+                msg = "Unrecognised channel_dtype of %s"
+                log.warning(msg, channel.metadata.channel_dtype)
+                continue
+
+            recent_values.append({record.metadata.timestamp: data})
 
         return recent_values
 

--- a/operationsgateway_api/src/routes/channels.py
+++ b/operationsgateway_api/src/routes/channels.py
@@ -50,11 +50,17 @@ async def get_channel_summary(
         [("_id", pymongo.DESCENDING)],
     )
 
+    msg = "Preferred colourmaps after user prefs check are %s, %s (float)"
     username = JwtHandler.get_payload(access_token)["username"]
     colourmap_name = await FalseColourHandler.get_preferred_colourmap(username)
-    log.debug("Preferred colour map after user prefs check is %s", colourmap_name)
+    float_colourmap = await FalseColourHandler.get_preferred_float_colourmap(username)
+    log.debug(msg, colourmap_name, float_colourmap)
 
-    recent_data = await Record.get_recent_channel_values(channel_name, colourmap_name)
+    recent_data = await Record.get_recent_channel_values(
+        channel_name,
+        colourmap_name,
+        float_colourmap,
+    )
 
     return ChannelSummaryModel(
         first_date=first_date,

--- a/test/endpoints/test_channel_summary.py
+++ b/test/endpoints/test_channel_summary.py
@@ -6,7 +6,12 @@ import imagehash
 from PIL import Image
 import pytest
 
-from test.conftest import set_preferred_colourmap, unset_preferred_colourmap
+from test.conftest import (
+    set_preferred_colourmap,
+    set_preferred_float_colourmap,
+    unset_preferred_colourmap,
+    unset_preferred_float_colourmap,
+)
 
 
 class TestChannelSummary:
@@ -77,6 +82,42 @@ class TestChannelSummary:
                 id="Image channel summary (using user's preferred colourmap)",
             ),
             pytest.param(
+                "FE-204-NSS-WFS",
+                {
+                    "first_date": "2023-06-05T08:03:00",
+                    "most_recent_date": "2023-06-05T08:03:00",
+                    "recent_sample": [
+                        {"2023-06-05T08:03:00": "cf2c39d3382c6363"},
+                    ],
+                },
+                False,
+                id="Float image channel summary (using system default colourmap)",
+            ),
+            pytest.param(
+                "FE-204-NSS-WFS",
+                {
+                    "first_date": "2023-06-05T08:03:00",
+                    "most_recent_date": "2023-06-05T08:03:00",
+                    "recent_sample": [
+                        {"2023-06-05T08:03:00": "ec3893c79c688f92"},
+                    ],
+                },
+                True,
+                id="Float image channel summary (using user's preferred colourmap)",
+            ),
+            pytest.param(
+                "FE-204-NSS-WFS-COEF",
+                {
+                    "first_date": "2023-06-05T08:03:00",
+                    "most_recent_date": "2023-06-05T08:03:00",
+                    "recent_sample": [
+                        {"2023-06-05T08:03:00": "83c0e03ef8c77f30"},
+                    ],
+                },
+                False,
+                id="Vector channel summary",
+            ),
+            pytest.param(
                 "FE-204-PSO-P1-PD",
                 {
                     "first_date": "2023-06-05T08:00:00",
@@ -107,6 +148,11 @@ class TestChannelSummary:
         """
 
         set_preferred_colourmap(test_app, login_and_get_token, use_preferred_colourmap)
+        set_preferred_float_colourmap(
+            test_app,
+            login_and_get_token,
+            use_preferred_colourmap,
+        )
 
         test_response = test_app.get(
             f"/channels/summary/{channel_name}",
@@ -122,6 +168,11 @@ class TestChannelSummary:
                 sample[timestamp] = str(imagehash.phash(img))
 
         unset_preferred_colourmap(
+            test_app,
+            login_and_get_token,
+            use_preferred_colourmap,
+        )
+        unset_preferred_float_colourmap(
             test_app,
             login_and_get_token,
             use_preferred_colourmap,

--- a/test/records/test_record.py
+++ b/test/records/test_record.py
@@ -215,6 +215,7 @@ class TestRecord:
             recent_data = await Record.get_recent_channel_values(
                 "test-scalar-channel",
                 "colourmap_name",
+                "float_colourmap",
             )
             assert recent_data == []
 


### PR DESCRIPTION
The new wavefront types (`FLOAT_IMAGE` and `VECTOR`) were missing from the if/elif block for requests to `/channels/summary`. Have added these, along with a warning if the channel dtype is unrecognised. I considered making it throw an error (since the dtype should be well controlled) but the existing tests assert that this is an empty list so I left the functionality as is.