### PR TITLE
Dsegog 414 investigate open search for metrics

### DIFF
--- a/operationsgateway_api/config.yml.example
+++ b/operationsgateway_api/config.yml.example
@@ -78,3 +78,7 @@ export:
   # 1048576 = 1 MB
   # 1073741824 = 1 GB
   max_filesize_bytes: 1073741824
+observability:
+  # used to view logs and traces in Elasticsearch run by Platforms & Services
+  environment: dev
+  secret_key: secret_key

--- a/operationsgateway_api/src/config.py
+++ b/operationsgateway_api/src/config.py
@@ -119,7 +119,7 @@ class ObservabilityConfig(BaseModel):
     """Configuration model class to store export observability details"""
 
     environment: StrictStr
-    secret: StrictStr
+    secret_key: StrictStr
 
 
 class APIConfig(BaseModel):

--- a/operationsgateway_api/src/config.py
+++ b/operationsgateway_api/src/config.py
@@ -115,6 +115,13 @@ class ExportConfig(BaseModel):
     max_filesize_bytes: StrictInt
 
 
+class ObservabilityConfig(BaseModel):
+    """Configuration model class to store export observability details"""
+
+    environment: StrictStr
+    secret: StrictStr
+
+
 class APIConfig(BaseModel):
     """
     Class to store the API's configuration settings

--- a/operationsgateway_api/src/config.py
+++ b/operationsgateway_api/src/config.py
@@ -140,6 +140,7 @@ class APIConfig(BaseModel):
     vectors: VectorsConfig
     echo: EchoConfig
     export: ExportConfig
+    observability: ObservabilityConfig
 
     @classmethod
     def load(cls, path=Path(__file__).parent.parent / "config.yml"):

--- a/operationsgateway_api/src/config.py
+++ b/operationsgateway_api/src/config.py
@@ -119,7 +119,7 @@ class ObservabilityConfig(BaseModel):
     """Configuration model class to store export observability details"""
 
     environment: StrictStr
-    secret_key: StrictStr
+    secret_key: StrictStr #apm key
 
 
 class APIConfig(BaseModel):

--- a/operationsgateway_api/src/main.py
+++ b/operationsgateway_api/src/main.py
@@ -2,6 +2,7 @@ import asyncio
 from contextlib import asynccontextmanager
 import logging
 
+from elasticapm.contrib.starlette import ElasticAPM, make_apm_client
 from fastapi import APIRouter, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -83,6 +84,17 @@ app = FastAPI(
     lifespan=lifespan,
     root_path=Config.config.app.url_prefix,
 )
+
+apm_config = {
+    "ENVIRONMENT": Config.config.observability.environment,
+    "SECRET_TOKEN": Config.config.observability.secret,
+    "SERVER_URL": "http://localhost:8200",
+    "SERVICE_NAME": "operationsgateway",
+    "ENABLED": True,
+}
+
+apm = make_apm_client(apm_config)
+app.add_middleware(ElasticAPM, client=apm)
 
 app.add_middleware(
     CORSMiddleware,

--- a/operationsgateway_api/src/main.py
+++ b/operationsgateway_api/src/main.py
@@ -87,7 +87,7 @@ app = FastAPI(
 
 apm_config = {
     "ENVIRONMENT": Config.config.observability.environment,
-    "SECRET_TOKEN": Config.config.observability.secret,
+    "SECRET_TOKEN": Config.config.observability.secret_key,
     "SERVER_URL": "http://localhost:8200",
     "SERVICE_NAME": "operationsgateway",
     "ENABLED": True,

--- a/poetry.lock
+++ b/poetry.lock
@@ -745,6 +745,48 @@ pipenv = ["pipenv"]
 poetry = ["poetry"]
 
 [[package]]
+name = "ecs-logging"
+version = "2.2.0"
+description = "Logging formatters for ECS (Elastic Common Schema) in Python"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "ecs_logging-2.2.0-py3-none-any.whl", hash = "sha256:f6e22d267770b06f797076f49b5fcc9d97108b22f452f5f9ed4b5367b1e61b5b"},
+    {file = "ecs_logging-2.2.0.tar.gz", hash = "sha256:1dc9e216f614129db0e6a2f9f926da4e4cf8edf8de16d1045a20aa8e950291d3"},
+]
+
+[package.extras]
+develop = ["elastic-apm", "mock", "pytest", "pytest-cov", "structlog"]
+
+[[package]]
+name = "elastic-apm"
+version = "6.23.0"
+description = "The official Python module for Elastic APM"
+optional = false
+python-versions = "<4,>=3.6"
+groups = ["main"]
+files = [
+    {file = "elastic-apm-6.23.0.tar.gz", hash = "sha256:1aeef4562486bd9ad611bba15f9eca5aeede6a737777541cb68c47c6cf5df7d4"},
+    {file = "elastic_apm-6.23.0-py2.py3-none-any.whl", hash = "sha256:5a1a17580560e70fba40b0a2e7682348422de5a9d2d13511efd05646eb4c62ae"},
+]
+
+[package.dependencies]
+certifi = "*"
+ecs-logging = "*"
+urllib3 = "<2.0.0 || >2.0.0,<3.0.0"
+wrapt = ">=1.14.1,<1.15.0 || >1.15.0"
+
+[package.extras]
+aiohttp = ["aiohttp"]
+flask = ["blinker"]
+opentelemetry = ["opentelemetry-api", "opentelemetry-sdk"]
+opentracing = ["opentracing (>=2.0.0)"]
+sanic = ["sanic"]
+starlette = ["starlette"]
+tornado = ["tornado"]
+
+[[package]]
 name = "epac-data-sim"
 version = "0.0.1"
 description = "Python application to simulate EPAC calendar schedule and data."
@@ -3571,7 +3613,7 @@ version = "1.17.2"
 description = "Module for decorators, wrappers and monkey patching."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "wrapt-1.17.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3d57c572081fed831ad2d26fd430d565b76aa277ed1d30ff4d40670b1c0dd984"},
     {file = "wrapt-1.17.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b5e251054542ae57ac7f3fba5d10bfff615b6c2fb09abeb37d2f1463f841ae22"},
@@ -3685,4 +3727,4 @@ xmlsec = ["xmlsec (>=0.6.1)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "248692ff33ced9861980b41f563d2272df9669214753a4bcfc2f6984d98603ae"
+content-hash = "7049addbaf0c7e999d3bee14e75e29ba53fbc7ba32dec266d4b7441f42b83369"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ httpx = "^0.23.3"
 # urllib3 isn't a dependency of this project, remove once the issue has been resolved
 urllib3 = ">=1.25.4,<1.27"
 lark = "1.1.9"
+elastic-apm = "^6.23.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.0"


### PR DESCRIPTION
This PR adds the necessary code changes for the application to speak to the local APM server (to be set up on the machine, either manually or by the Ansible script). Ideally, we'd use environment variables for this, but I've stuck with the convention of having everything in a config file so as not to mix and match.

There might be a bit of back and forth with this as I try to get everything talking. First step is these changes, then to get the APM server working on the rig VM, then get the Elastic session set up. Mehmet has sent through instructions for these.