### PR TITLE
Return system defaults from get_preferred_colourmap and get_preferred_float_colourmap

### DIFF
--- a/operationsgateway_api/src/records/false_colour_handler.py
+++ b/operationsgateway_api/src/records/false_colour_handler.py
@@ -39,7 +39,7 @@ class FalseColourHandler:
             pref_name = FalseColourHandler.preferred_colour_map_pref_name
             return await UserPreferences.get(username, pref_name)
         except MissingAttributeError:
-            return None
+            return FalseColourHandler.default_colour_map_name
 
     @staticmethod
     async def get_preferred_float_colourmap(username: str) -> str:
@@ -52,7 +52,7 @@ class FalseColourHandler:
             pref_name = FalseColourHandler.preferred_float_colour_map_pref_name
             return await UserPreferences.get(username, pref_name)
         except MissingAttributeError:
-            return None
+            return FalseColourHandler.default_float_colour_map_name
 
     @staticmethod
     def create_colourbar(

--- a/operationsgateway_api/src/records/false_colour_handler.py
+++ b/operationsgateway_api/src/records/false_colour_handler.py
@@ -147,8 +147,7 @@ class FalseColourHandler:
             upper_level=upper_level,
             limit_bit_depth=limit_bit_depth,
         )
-        if colourmap_name is None:
-            colourmap_name = FalseColourHandler.default_colour_map_name
+        colourmap_name = colourmap_name or FalseColourHandler.default_colour_map_name
         if not ColourmapMapping.is_colourmap_available(
             FalseColourHandler.colourmap_names,
             colourmap_name,
@@ -178,8 +177,9 @@ class FalseColourHandler:
         position of 0 at the centre of the colourmap, the absolute_max pixel value is
         used to set both vmin and vmax.
         """
-        if colourmap_name is None:
-            colourmap_name = FalseColourHandler.default_float_colour_map_name
+        colourmap_name = (
+            colourmap_name or FalseColourHandler.default_float_colour_map_name
+        )
         if not ColourmapMapping.is_colourmap_available(
             FalseColourHandler.colourmap_names,
             colourmap_name,

--- a/operationsgateway_api/src/routes/records.py
+++ b/operationsgateway_api/src/routes/records.py
@@ -112,6 +112,9 @@ async def get_records(
     if colourmap_name is None:
         colourmap_name = await Image.get_preferred_colourmap(access_token)
 
+    if float_colourmap_name is None:
+        float_colourmap_name = await FloatImage.get_preferred_colourmap(access_token)
+
     vector_skip, vector_limit = await Vector.get_skip_limit(access_token)
     for record_data in records_data:
         if record_data.channels:
@@ -254,6 +257,11 @@ async def get_record_by_id(
     if record_data.channels:
         if colourmap_name is None:
             colourmap_name = await Image.get_preferred_colourmap(access_token)
+
+        if float_colourmap_name is None:
+            float_colourmap_name = await FloatImage.get_preferred_colourmap(
+                access_token,
+            )
 
         vector_skip, vector_limit = await Vector.get_skip_limit(access_token)
         await Record.apply_false_colour_to_thumbnails(

--- a/operationsgateway_api/src/routes/records.py
+++ b/operationsgateway_api/src/routes/records.py
@@ -109,11 +109,10 @@ async def get_records(
         projection,
     )
 
-    if colourmap_name is None:
-        colourmap_name = await Image.get_preferred_colourmap(access_token)
-
-    if float_colourmap_name is None:
-        float_colourmap_name = await FloatImage.get_preferred_colourmap(access_token)
+    colourmap_name = colourmap_name or await Image.get_preferred_colourmap(access_token)
+    float_colourmap_name = (
+        float_colourmap_name or await FloatImage.get_preferred_colourmap(access_token)
+    )
 
     vector_skip, vector_limit = await Vector.get_skip_limit(access_token)
     for record_data in records_data:
@@ -255,13 +254,14 @@ async def get_record_by_id(
     record_data = await Record.find_record_by_id(id_, conditions)
 
     if record_data.channels:
-        if colourmap_name is None:
-            colourmap_name = await Image.get_preferred_colourmap(access_token)
-
-        if float_colourmap_name is None:
-            float_colourmap_name = await FloatImage.get_preferred_colourmap(
-                access_token,
+        colourmap_name = (
+            colourmap_name or await Image.get_preferred_colourmap(access_token)
+        )
+        float_colourmap_name = (
+            float_colourmap_name or await FloatImage.get_preferred_colourmap(
+                access_token
             )
+        )
 
         vector_skip, vector_limit = await Vector.get_skip_limit(access_token)
         await Record.apply_false_colour_to_thumbnails(

--- a/operationsgateway_api/src/routes/records.py
+++ b/operationsgateway_api/src/routes/records.py
@@ -254,13 +254,12 @@ async def get_record_by_id(
     record_data = await Record.find_record_by_id(id_, conditions)
 
     if record_data.channels:
-        colourmap_name = (
-            colourmap_name or await Image.get_preferred_colourmap(access_token)
+        colourmap_name = colourmap_name or await Image.get_preferred_colourmap(
+            access_token,
         )
         float_colourmap_name = (
-            float_colourmap_name or await FloatImage.get_preferred_colourmap(
-                access_token
-            )
+            float_colourmap_name
+            or await FloatImage.get_preferred_colourmap(access_token)
         )
 
         vector_skip, vector_limit = await Vector.get_skip_limit(access_token)

--- a/test/endpoints/test_channel_summary.py
+++ b/test/endpoints/test_channel_summary.py
@@ -87,7 +87,7 @@ class TestChannelSummary:
                     "first_date": "2023-06-05T08:03:00",
                     "most_recent_date": "2023-06-05T08:03:00",
                     "recent_sample": [
-                        {"2023-06-05T08:03:00": "cf2c39d3382c6363"},
+                        {"2023-06-05T08:03:00": "93cf6c1833976165"},
                     ],
                 },
                 False,


### PR DESCRIPTION
While ingesting wavefront data to the dev instance, noticed that the thumbnail for the float image uses `viridis`:
![image](https://github.com/user-attachments/assets/c24710d9-b100-4b6d-b76c-583402b19209)

Despite the fact that the "system default" for floats should be `bwr`:
https://github.com/ral-facilities/operationsgateway-api/blob/8955ad50b418149a575222f738347497c219ef7f/operationsgateway_api/config.yml.example#L25

Having looked into it, this was a combination of not calling `FloatImage.get_preferred_colourmap()` in the records endpoints and the fact that if a user pref isn't found, both the method for traditional and floating point images were returning `None`. MatPlotLib defaults to `viridis` if `None` is passed:
```python
>>> import matplotlib.pyplot as plt
>>> plt.cm.get_cmap(None).name
'viridis'
```
Which is undetectable for the traditional images where the "system default" is `viridis` anyway, but is bad for floats which should always use a diverging colourmap to show the positive/negative regions.

Updated the phash in the tests from the hash of:
![FE-204-NSS-WFS_before](https://github.com/user-attachments/assets/23f41287-cf79-4b15-a4b0-07bb11a000e8)

to:
![FE-204-NSS-WFSFalse](https://github.com/user-attachments/assets/3be85893-0fa8-4d04-87f5-6c86f8ff9454)

Also changed some of the places we were checking if the colourmap was None to use a single assignment using `or` instead. There shouldn't be any functional impact of this, but gets high patch coverage since technically that line always runs without being counted as a "partial" on the if statement. Happy to revert this though if people find it less readable than an explicit if.