### PR TITLE
Implement lru_cache for EchoInterface

### DIFF
--- a/operationsgateway_api/src/records/echo_interface.py
+++ b/operationsgateway_api/src/records/echo_interface.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from io import BytesIO
 import logging
 
@@ -197,3 +198,12 @@ class EchoInterface:
                 f"{exc.response['Error']['Code']} when deleting file at"
                 f" '{dir_path}'",
             ) from exc
+
+
+@lru_cache
+def get_echo_interface() -> EchoInterface:
+    """
+    Returns:
+        EchoInterface: Cached object for interacting with Echo object storage.
+    """
+    return EchoInterface()

--- a/operationsgateway_api/src/records/ingestion/partial_import_checks.py
+++ b/operationsgateway_api/src/records/ingestion/partial_import_checks.py
@@ -8,7 +8,7 @@ from operationsgateway_api.src.models import (
     VectorChannelModel,
     WaveformChannelModel,
 )
-from operationsgateway_api.src.records.echo_interface import EchoInterface
+from operationsgateway_api.src.records.echo_interface import get_echo_interface
 from operationsgateway_api.src.records.float_image import FloatImage
 from operationsgateway_api.src.records.image import Image
 from operationsgateway_api.src.records.vector import Vector
@@ -26,7 +26,7 @@ class PartialImportChecks:
         """
         self.ingested_record = ingested_record
         self.stored_record = stored_record
-        self.echo = EchoInterface()
+        self.echo_interface = get_echo_interface()
 
     def metadata_checks(self):
         """
@@ -97,16 +97,16 @@ class PartialImportChecks:
             if channel_name in self.stored_record.channels:
                 if isinstance(channel_model, ImageChannelModel):
                     path = Image.get_full_path(channel_model.image_path)
-                    object_stored = self.echo.head_object(path)
+                    object_stored = self.echo_interface.head_object(path)
                 elif isinstance(channel_model, FloatImageChannelModel):
                     path = FloatImage.get_full_path(channel_model.image_path)
-                    object_stored = self.echo.head_object(path)
+                    object_stored = self.echo_interface.head_object(path)
                 elif isinstance(channel_model, WaveformChannelModel):
                     path = Waveform.get_full_path(channel_model.waveform_path)
-                    object_stored = self.echo.head_object(path)
+                    object_stored = self.echo_interface.head_object(path)
                 elif isinstance(channel_model, VectorChannelModel):
                     path = Vector.get_full_path(channel_model.vector_path)
-                    object_stored = self.echo.head_object(path)
+                    object_stored = self.echo_interface.head_object(path)
                 else:
                     object_stored = True
                 if object_stored:

--- a/operationsgateway_api/src/routes/records.py
+++ b/operationsgateway_api/src/routes/records.py
@@ -13,7 +13,10 @@ from operationsgateway_api.src.auth.authorisation import (
 from operationsgateway_api.src.error_handling import endpoint_error_handling
 from operationsgateway_api.src.exceptions import QueryParameterError
 from operationsgateway_api.src.models import PartialRecordModel
-from operationsgateway_api.src.records.echo_interface import EchoInterface
+from operationsgateway_api.src.records.echo_interface import (
+    EchoInterface,
+    get_echo_interface,
+)
 from operationsgateway_api.src.records.float_image import FloatImage
 from operationsgateway_api.src.records.image import Image
 from operationsgateway_api.src.records.record import Record as Record
@@ -300,26 +303,26 @@ async def delete_record_by_id(
     log.info("Deleting record by ID: %s", id_)
 
     await Record.delete_record(id_)
-    echo = EchoInterface()
+    echo_interface = get_echo_interface()
     # In principle historic data might be in the old directory format on Echo, so delete
     # in both locations
     sub_directories = EchoInterface.format_record_id(record_id=id_)
     directory = EchoInterface.format_record_id(record_id=id_, use_subdirectories=False)
 
     log.info("Deleting waveforms for record ID '%s'", id_)
-    echo.delete_directory(f"{Waveform.echo_prefix}/{sub_directories}/")
-    echo.delete_directory(f"{Waveform.echo_prefix}/{directory}/")
+    echo_interface.delete_directory(f"{Waveform.echo_prefix}/{sub_directories}/")
+    echo_interface.delete_directory(f"{Waveform.echo_prefix}/{directory}/")
 
     log.info("Deleting images for record ID '%s'", id_)
-    echo.delete_directory(f"{Image.echo_prefix}/{sub_directories}/")
-    echo.delete_directory(f"{Image.echo_prefix}/{directory}/")
+    echo_interface.delete_directory(f"{Image.echo_prefix}/{sub_directories}/")
+    echo_interface.delete_directory(f"{Image.echo_prefix}/{directory}/")
 
     log.info("Deleting vectors for record ID '%s'", id_)
-    echo.delete_directory(f"{Vector.echo_prefix}/{sub_directories}/")
-    echo.delete_directory(f"{Vector.echo_prefix}/{directory}/")
+    echo_interface.delete_directory(f"{Vector.echo_prefix}/{sub_directories}/")
+    echo_interface.delete_directory(f"{Vector.echo_prefix}/{directory}/")
 
     log.info("Deleting float images for record ID '%s'", id_)
-    echo.delete_directory(f"{FloatImage.echo_prefix}/{sub_directories}/")
-    echo.delete_directory(f"{FloatImage.echo_prefix}/{directory}/")
+    echo_interface.delete_directory(f"{FloatImage.echo_prefix}/{sub_directories}/")
+    echo_interface.delete_directory(f"{FloatImage.echo_prefix}/{directory}/")
 
     return Response(status_code=HTTPStatus.NO_CONTENT.value)

--- a/test/endpoints/test_get_vector.py
+++ b/test/endpoints/test_get_vector.py
@@ -1,11 +1,7 @@
-import json
-from urllib.parse import quote
-
 from fastapi.testclient import TestClient
-import pytest
 
 
-class TestGetWaveformByID:
+class TestGetVectorById:
     def test_get_vector(
         self,
         test_app: TestClient,

--- a/test/records/ingestion/test_partial_import.py
+++ b/test/records/ingestion/test_partial_import.py
@@ -408,7 +408,8 @@ class TestPartialImport:
         # waveform channels, a check is conducted to make sure the associated
         # image/waveform is actually on Echo and because we're not using stored data for
         # this test, we need to mock that check
-        with patch.object(partial_import_checker.echo, "head_object") as mock_is_stored:
+        echo_interface = partial_import_checker.echo_interface
+        with patch.object(echo_interface, "head_object") as mock_is_stored:
             mock_is_stored.return_value = True
             partial_import_channel_checks = partial_import_checker.channel_checks(
                 {"rejected_channels": {}},


### PR DESCRIPTION
Will have conflicts with #195 as they both alter the get method for channel objects.

Replaces the `EchoInterface()` calls with `lru_cache` to prevent the overhead of initialising the object (up to ~0.4 seconds) for example in export which can call this 10s - 100s of times. In practice, the time it takes for all Echo calls is very inconsistent so the benefit may be less noticeable.

As a precaution against holding the same boto3 connection open for the lifetime of the application, during error handling for the calls which use `echo_interface` invalidate the cache. This means the next time we try to get the interface, it will be a fresh one.