### PR TITLE
Wrap EchoInterface.download_file_object in alru_cache

### DIFF
--- a/operationsgateway_api/src/config.py
+++ b/operationsgateway_api/src/config.py
@@ -8,6 +8,7 @@ from pydantic import (
     BaseModel,
     field_validator,
     FilePath,
+    NonNegativeInt,
     SecretStr,
     StrictBool,
     StrictInt,
@@ -62,6 +63,7 @@ class EchoConfig(BaseModel):
     access_key: SecretStr
     secret_key: SecretStr
     bucket_name: StrictStr
+    cache_maxsize: NonNegativeInt = 128
 
 
 class MongoDB(BaseModel):

--- a/operationsgateway_api/src/records/channel_object_abc.py
+++ b/operationsgateway_api/src/records/channel_object_abc.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from io import BytesIO
 import logging
 
 from operationsgateway_api.src.exceptions import EchoS3Error
@@ -51,7 +50,7 @@ class ChannelObjectABC(ABC):
         record_id: str,
         channel_name: str,
         use_subdirectories: bool = True,
-    ) -> BytesIO:
+    ) -> bytes:
         """
         Gets the bytes for this record and channel, handling any exceptions.
         """

--- a/operationsgateway_api/src/records/export_handler.py
+++ b/operationsgateway_api/src/records/export_handler.py
@@ -334,9 +334,9 @@ class ExportHandler:
                 image_bytes = channels[channel_name].data
             elif channel_name in raw_data:
                 if self.original_image:
-                    image_bytes = raw_data[channel_name].getvalue()
+                    image_bytes = raw_data[channel_name]
                 else:
-                    image_bytes_io = Image.apply_false_colour(
+                    image_bytes = Image.apply_false_colour(
                         image_bytes=raw_data[channel_name],
                         original_image=self.original_image,
                         lower_level=self.lower_level,
@@ -344,9 +344,8 @@ class ExportHandler:
                         limit_bit_depth=self.limit_bit_depth,
                         colourmap_name=self.colourmap_name,
                     )
-                    image_bytes = image_bytes_io.getvalue()
             else:
-                image_bytes_io = await Image.get_image(
+                image_bytes = await Image.get_image(
                     record_id=record_id,
                     channel_name=channel_name,
                     original_image=self.original_image,
@@ -355,7 +354,6 @@ class ExportHandler:
                     limit_bit_depth=self.limit_bit_depth,
                     colourmap_name=self.colourmap_name,
                 )
-                image_bytes = image_bytes_io.getvalue()
             self.zip_file.writestr(f"{record_id}_{channel_name}.png", image_bytes)
             self._check_zip_file_size()
         except Exception:
@@ -383,10 +381,7 @@ class ExportHandler:
                 record_id,
                 channel_name,
             )
-            self.zip_file.writestr(
-                f"{record_id}_{channel_name}.npz",
-                storage_bytes.getvalue(),
-            )
+            self.zip_file.writestr(f"{record_id}_{channel_name}.npz", storage_bytes)
             self._check_zip_file_size()
         except Exception:
             self.errors_file_in_memory.write(

--- a/operationsgateway_api/src/records/float_image.py
+++ b/operationsgateway_api/src/records/float_image.py
@@ -87,8 +87,7 @@ class FloatImage(ImageABC):
         """
         log.info("Retrieving float image and returning BytesIO object")
         array_bytes = await FloatImage.get_bytes(record_id, channel_name)
-        array_bytes.seek(0)
-        npz_file = np.load(array_bytes)
+        npz_file = np.load(BytesIO(array_bytes))
         array = npz_file["arr_0"]
         npz_file.close()
         absolute_max = FloatImage.get_absolute_max(array)

--- a/operationsgateway_api/src/records/image.py
+++ b/operationsgateway_api/src/records/image.py
@@ -144,10 +144,10 @@ class Image(ImageABC):
         upper_level: int,
         limit_bit_depth: int,
         colourmap_name: str,
-    ) -> BytesIO:
+    ) -> bytes:
         """
-        Retrieve an image from Echo S3 and return the bytes of the image in a BytesIO
-        object depending on what the user has requested.
+        Retrieve an image from Echo S3 and return the bytes of the image depending on
+        what the user has requested.
 
         If 'original_image' is set to True then just return the unprocessed bytes of the
         image read from Echo S3, otherwise apply false colour to the image either using
@@ -175,13 +175,13 @@ class Image(ImageABC):
 
     @staticmethod
     def apply_false_colour(
-        image_bytes: BytesIO,
+        image_bytes: bytes,
         original_image: bool,
         lower_level: int,
         upper_level: int,
         limit_bit_depth: int,
         colourmap_name: str,
-    ) -> BytesIO:
+    ) -> bytes:
         """
         If not requesting the `original_image`, then false colour will be applied to
         `image_bytes` using the other parameters.
@@ -191,7 +191,7 @@ class Image(ImageABC):
             return image_bytes
         else:
             log.debug("False colour requested, applying false colour to image")
-            img_src = PILImage.open(image_bytes)
+            img_src = PILImage.open(BytesIO(image_bytes))
             orig_img_array = np.array(img_src)
             storage_bit_depth = FalseColourHandler.get_pixel_depth(img_src)
             false_colour_image = FalseColourHandler.apply_false_colour(
@@ -203,7 +203,7 @@ class Image(ImageABC):
                 colourmap_name=colourmap_name,
             )
             img_src.close()
-            return false_colour_image
+            return false_colour_image.getvalue()
 
     @staticmethod
     async def get_preferred_colourmap(access_token: str) -> str:

--- a/operationsgateway_api/src/records/record_retriever.py
+++ b/operationsgateway_api/src/records/record_retriever.py
@@ -1,4 +1,5 @@
 import asyncio
+from io import BytesIO
 import logging
 
 import numpy as np
@@ -260,7 +261,7 @@ class RecordRetriever:
         )
         self.raw_data[channel_name] = image_bytes
 
-        img_src = PILImage.open(image_bytes)
+        img_src = PILImage.open(BytesIO(image_bytes))
         img_array = np.array(img_src)
         variable_value = Record._bit_shift_to_raw(
             img_array=img_array,

--- a/operationsgateway_api/src/records/vector.py
+++ b/operationsgateway_api/src/records/vector.py
@@ -36,7 +36,7 @@ class Vector(ChannelObjectABC):
             record_id=record_id,
             channel_name=channel_name,
         )
-        vector_dict = json.loads(bytes_io.getvalue().decode())
+        vector_dict = json.loads(bytes_io.decode())
         return VectorModel(**vector_dict)
 
     @staticmethod

--- a/operationsgateway_api/src/records/waveform.py
+++ b/operationsgateway_api/src/records/waveform.py
@@ -139,9 +139,9 @@ class Waveform(ChannelObjectABC):
         the waveform should exist; if no waveform can be found, an Exception will
         be raised
         """
-        bytes_io = await Waveform.get_bytes(
+        waveform_bytes = await Waveform.get_bytes(
             record_id=record_id,
             channel_name=channel_name,
         )
-        waveform_data = json.loads(bytes_io.getvalue().decode())
+        waveform_data = json.loads(waveform_bytes.decode())
         return WaveformModel(**waveform_data)

--- a/operationsgateway_api/src/routes/images.py
+++ b/operationsgateway_api/src/routes/images.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 import logging
 from typing import List, Optional
 
@@ -282,7 +283,7 @@ async def get_image_bytes(
                 await record_retriever.process_functions()
                 return record_retriever.record.channels[channel_name].data
 
-    bytes_io = await Image.get_image(
+    return await Image.get_image(
         record_id=record_id,
         channel_name=channel_name,
         original_image=original_image,
@@ -291,7 +292,6 @@ async def get_image_bytes(
         limit_bit_depth=limit_bit_depth,
         colourmap_name=colourmap_name,
     )
-    return bytes_io.getvalue()
 
 
 async def get_image_array(
@@ -324,7 +324,7 @@ async def get_image_array(
                 await record_retriever.process_functions()
                 return record_retriever.record.channels[channel_name].variable_value
 
-    bytes_io = await Image.get_image(
+    image_bytes = await Image.get_image(
         record_id=record_id,
         channel_name=channel_name,
         original_image=original_image,
@@ -333,5 +333,5 @@ async def get_image_array(
         limit_bit_depth=limit_bit_depth,
         colourmap_name=colourmap_name,
     )
-    image = PILImage.open(bytes_io)
+    image = PILImage.open(BytesIO(image_bytes))
     return np.array(image)

--- a/poetry.lock
+++ b/poetry.lock
@@ -242,6 +242,18 @@ test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "except
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
+name = "async-lru"
+version = "2.0.5"
+description = "Simple LRU cache for asyncio"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "async_lru-2.0.5-py3-none-any.whl", hash = "sha256:ab95404d8d2605310d345932697371a5f40def0487c03d6d0ad9138de52c9943"},
+    {file = "async_lru-2.0.5.tar.gz", hash = "sha256:481d52ccdd27275f42c43a928b4a50c3bfb2d67af4e78b170e3e0bb39c66e5bb"},
+]
+
+[[package]]
 name = "attrs"
 version = "25.3.0"
 description = "Classes Without Boilerplate"
@@ -4432,4 +4444,4 @@ xmlsec = ["xmlsec (>=0.6.1)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "b0c06756738fb88587cdbd118da1d4d5a8597ae7adfe70fddab5f93ac9a7ae4c"
+content-hash = "3f4985fc72204ad7c3f5d657d05bc4d710ee9ba6d333023baa981fb6abbda426"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ elastic-apm = "^6.23.0"
 aioboto3 = "^13.0.0"
 aiobotocore = ">=2.16.0, <2.17.0"
 mypy-boto3-s3 = "^1.40.0"
+async-lru = "^2.0.5"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.0"

--- a/test/images/test_float_image.py
+++ b/test/images/test_float_image.py
@@ -143,7 +143,7 @@ class TestImage:
         with patch(
             "operationsgateway_api.src.records.echo_interface.EchoInterface"
             ".download_file_object",
-            return_value=BytesIO(self.stored_bytes),
+            return_value=self.stored_bytes,
         ):
             test_image = await FloatImage.get_image(
                 record_id="test_record_id",
@@ -151,7 +151,7 @@ class TestImage:
                 colourmap_name="bwr",
             )
 
-        phash = str(imagehash.phash(Image.open(BytesIO(test_image.getvalue()))))
+        phash = str(imagehash.phash(Image.open(test_image)))
         assert phash == "926e4ba649a6cc5e"
 
     @pytest.mark.asyncio

--- a/test/records/test_echo_interface.py
+++ b/test/records/test_echo_interface.py
@@ -1,6 +1,6 @@
 from io import BytesIO
 from typing import AsyncGenerator
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 from botocore.exceptions import ClientError
 import pytest
@@ -94,3 +94,24 @@ class TestEchoInterface:
         echo_interface = EchoInterface()
         echo_interface._bucket = await echo_interface.get_bucket()
         assert not await echo_interface.head_object("test")
+
+    @pytest.mark.asyncio
+    async def test_cached_bytes(self):
+        echo_interface = EchoInterface()
+        echo_interface._bucket = await echo_interface.get_bucket()
+        echo_interface._bucket.download_fileobj = MagicMock(
+            wraps=echo_interface._bucket.download_fileobj,
+        )
+        # First call results in download
+        object_path = "images/2023/06/05/100000/FE-204-NSO-P1-CAM-1.png"
+        await echo_interface.download_file_object(object_path)
+        echo_interface._bucket.download_fileobj.assert_called_once_with(
+            Fileobj=ANY,
+            Key=object_path,
+        )
+        # Second call does not result in an additional download as bytes are cached
+        await echo_interface.download_file_object(object_path)
+        echo_interface._bucket.download_fileobj.assert_called_once_with(
+            Fileobj=ANY,
+            Key=object_path,
+        )


### PR DESCRIPTION
Note: this is dependent on #199 as it uses `alru_cache`. You could do basically the same thing with `lru_cache`, but given Stephen's recent email requesting that we put the asynchronous/concurrent Echo onto prod I'm assuming that the former is the right thing to use.

- Add `cach_maxsize` config option, which defaults to the same default `maxsize` of `alru_cache` (128)
  - Based on looking at `htop` while the API runs, this seemed to result in ~1GB more RAM usage
- In order to use `alru_cache`, had to replace `BytesIO` with bytes as the return value of `EchoInterface.download_file_object`. `BytesIO` can be closed, which means it can't be safely cached and re-used like the raw `bytes`. In some places this now means we don't have to call `getvalue` to get the `bytes` since we already return them, in others (loading with PIL and numpy) we now wrap the `bytes` in `BytesIO`.
- Added a new test which wraps the underlying call and asserts that it is only called once if you request the same image twice (i.e. the second call uses the cached bytes and doesn't transfer anything from Echo)