### PR TITLE
Checking that refresh token now contains the username

### DIFF
--- a/operationsgateway_api/src/auth/jwt_handler.py
+++ b/operationsgateway_api/src/auth/jwt_handler.py
@@ -106,6 +106,7 @@ class JwtHandler:
         try:
             access_payload = JwtHandler.get_payload(access_token, {"verify_exp": False})
 
+            # make sure the user associated with the refresh token is also associated with the access token
             if refresh_payload.get("username") != access_payload.get("username"):
                 message = "Refresh token does not match access token user"
                 log.warning(message)

--- a/operationsgateway_api/src/auth/jwt_handler.py
+++ b/operationsgateway_api/src/auth/jwt_handler.py
@@ -66,6 +66,7 @@ class JwtHandler:
         :return: The refresh JWT
         """
         payload = {}
+        payload["username"] = self.user_model.username
         payload["exp"] = datetime.now(timezone.utc) + timedelta(
             days=Config.config.auth.refresh_token_validity_days,
         )
@@ -95,18 +96,29 @@ class JwtHandler:
         :param access_token: The JWT access token
         :return: The access token JWT with an updated expiry time
         """
-        JwtHandler.verify_token(refresh_token)
+        refresh_payload = JwtHandler.verify_token(refresh_token)
+
         # additional check to ensure the token has not been blacklisted
         if refresh_token in JwtHandler.get_blacklisted_tokens():
             message = "Token is blacklisted"
             log.warning(message)
             raise ForbiddenError(message)
         try:
-            payload = JwtHandler.get_payload(access_token, {"verify_exp": False})
-            payload["exp"] = datetime.now(timezone.utc) + timedelta(
+            access_payload = JwtHandler.get_payload(access_token, {"verify_exp": False})
+
+            if refresh_payload.get("username") != access_payload.get("username"):
+                message = "Refresh token does not match access token user"
+                log.warning(message)
+                raise ForbiddenError(message)
+
+            access_payload["exp"] = datetime.now(timezone.utc) + timedelta(
                 minutes=Config.config.auth.access_token_validity_mins,
             )
-            return JwtHandler._pack_jwt(payload)
+
+            return JwtHandler._pack_jwt(access_payload)
+
+        except ForbiddenError:
+            raise
         except Exception as exc:
             message = "Unable to refresh token"
             log.warning(message, exc_info=1)

--- a/operationsgateway_api/src/auth/jwt_handler.py
+++ b/operationsgateway_api/src/auth/jwt_handler.py
@@ -106,7 +106,8 @@ class JwtHandler:
         try:
             access_payload = JwtHandler.get_payload(access_token, {"verify_exp": False})
 
-            # make sure the user associated with the refresh token is also associated with the access token
+            # make sure the user associated with the refresh token is also
+            # associated with the access token
             if refresh_payload.get("username") != access_payload.get("username"):
                 message = "Refresh token does not match access token user"
                 log.warning(message)

--- a/test/auth/test_jwt_handler.py
+++ b/test/auth/test_jwt_handler.py
@@ -49,3 +49,25 @@ class TestJwtHandler:
             return_value = jwt_handler_instance.get_blacklisted_tokens()
 
         assert return_value == ["test_token1", "test_token2", "test_token3"]
+
+    def test_refresh_token_user_mismatch(self, jwt_handler_instance):
+        with patch(
+                "operationsgateway_api.src.auth.jwt_handler.JwtHandler.verify_token",
+                return_value={"username": "refresh_user"},
+        ):
+            with patch(
+                    "operationsgateway_api.src.auth.jwt_handler.JwtHandler.get_blacklisted_tokens",
+                    return_value=[],
+            ):
+                with patch(
+                        "operationsgateway_api.src.auth.jwt_handler.JwtHandler.get_payload",
+                        return_value={"username": "access_user"},
+                ):
+                    with pytest.raises(
+                            ForbiddenError,
+                            match="Refresh token does not match access token user",
+                    ):
+                        jwt_handler_instance.refresh_token(
+                            "test_refresh_token",
+                            "test_access_token",
+                        )

--- a/test/auth/test_jwt_handler.py
+++ b/test/auth/test_jwt_handler.py
@@ -52,20 +52,20 @@ class TestJwtHandler:
 
     def test_refresh_token_user_mismatch(self, jwt_handler_instance):
         with patch(
-                "operationsgateway_api.src.auth.jwt_handler.JwtHandler.verify_token",
-                return_value={"username": "refresh_user"},
+            "operationsgateway_api.src.auth.jwt_handler.JwtHandler.verify_token",
+            return_value={"username": "refresh_user"},
         ):
             with patch(
-                    "operationsgateway_api.src.auth.jwt_handler.JwtHandler.get_blacklisted_tokens",
-                    return_value=[],
+                "operationsgateway_api.src.auth.jwt_handler.JwtHandler.get_blacklisted_tokens",
+                return_value=[],
             ):
                 with patch(
-                        "operationsgateway_api.src.auth.jwt_handler.JwtHandler.get_payload",
-                        return_value={"username": "access_user"},
+                    "operationsgateway_api.src.auth.jwt_handler.JwtHandler.get_payload",
+                    return_value={"username": "access_user"},
                 ):
                     with pytest.raises(
-                            ForbiddenError,
-                            match="Refresh token does not match access token user",
+                        ForbiddenError,
+                        match="Refresh token does not match access token user",
                     ):
                         jwt_handler_instance.refresh_token(
                             "test_refresh_token",

--- a/util/realistic_data/ingest_echo_data.py
+++ b/util/realistic_data/ingest_echo_data.py
@@ -52,6 +52,8 @@ def main():
 
     channel_manifest = echo.download_manifest_file()
     og_api = APIClient(api_url, starter.process)
+    print("submitting manifest")
+
     og_api.submit_manifest(channel_manifest)
 
     hdf_page_iterator = echo.paginate_hdf_data()


### PR DESCRIPTION
Checking that refresh token now contains the username and it matches the corresponding access token. Nothing changes on the FE.

To recap, the flow is now:

on `/login`

- API authenticates users in existing ways
- API returns an access JWT in the response body.
- API also sets a refresh JWT as an HttpOnly cookie.
- Access token contains:
    - username
    - authorised_routes
    - userIsAdmin
    - exp
- Refresh token now contains:
    - username
    - exp

Then on /refresh:
- Client sends the existing access token in the body.
- Browser also sends the refresh token cookie.
- API verifies the refresh token signature and expiry.
- API checks the refresh token is not blacklisted.
- API decodes the access token
- API compares username
    - If they match, it extends the access token expiry and returns a new access token.
    - If they do not match, it rejects the refresh.